### PR TITLE
Add DOB stalled construction data and vacant lot mart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ tiles.cors:
 	gcloud storage buckets update $(bucket) --cors-file=config/gcloud-bucket-cors-config.json
 
 ## BigQuery data loading
-## Usage: make bq.load.permits CSV=local/data/DOB_Permit_Issuance_20260216.csv
+## Usage: make bq.load.permits CSV=local/data/DOB_Permit_Issuance.csv
 
 bq.load.permits:
 	bq load --source_format=CSV --skip_leading_rows=1 --allow_quoted_newlines \
@@ -62,6 +62,12 @@ bq.load.stalled:
 		empty-lots:raw_dob.stalled_construction \
 		$(CSV) \
 		build/schemas/stalled_construction.json
+
+bq.load.building:
+	bq load --source_format=CSV --skip_leading_rows=1 --allow_quoted_newlines \
+		empty-lots:raw_dob.building \
+		$(CSV) \
+		build/schemas/building.json
 
 create_image.tippecanoe:
 	./build/create_tippecanoe_image.sh

--- a/build/schemas/building.json
+++ b/build/schemas/building.json
@@ -1,0 +1,18 @@
+[
+  {"name": "the_geom", "type": "STRING"},
+  {"name": "NAME", "type": "STRING"},
+  {"name": "BIN", "type": "STRING"},
+  {"name": "DOITT_ID", "type": "STRING"},
+  {"name": "SHAPE_AREA", "type": "STRING"},
+  {"name": "BASE_BBL", "type": "STRING"},
+  {"name": "OBJECTID", "type": "STRING"},
+  {"name": "Construction_Year", "type": "STRING"},
+  {"name": "Feature_Code", "type": "STRING"},
+  {"name": "Geometry_Source", "type": "STRING"},
+  {"name": "Ground_Elevation", "type": "STRING"},
+  {"name": "Height_Roof", "type": "STRING"},
+  {"name": "LAST_EDITED_DATE", "type": "STRING"},
+  {"name": "LAST_STATUS_TYPE", "type": "STRING"},
+  {"name": "Map_Pluto_BBL", "type": "STRING"},
+  {"name": "Length", "type": "STRING"}
+]

--- a/build/schemas/stalled_construction.json
+++ b/build/schemas/stalled_construction.json
@@ -1,0 +1,10 @@
+[
+  {"name": "Borough_Name", "type": "STRING"},
+  {"name": "Community_Board", "type": "STRING"},
+  {"name": "BIN", "type": "STRING"},
+  {"name": "House_Number", "type": "STRING"},
+  {"name": "Street_Name", "type": "STRING"},
+  {"name": "Complaint_Number", "type": "STRING"},
+  {"name": "Date_Complaint_Received", "type": "STRING"},
+  {"name": "DOBRunDate", "type": "STRING"}
+]

--- a/dbt/models/intermediate/int_stalled_construction.sql
+++ b/dbt/models/intermediate/int_stalled_construction.sql
@@ -1,0 +1,17 @@
+/*
+    Deduplicated stalled construction sites.
+    One row per complaint + BIN — the raw data has daily snapshots.
+    A single complaint can span multiple BINs (buildings).
+*/
+
+select
+    bin,
+    borough,
+    house_number,
+    street_name,
+    complaint_number,
+    bbl_key,
+    min(complaint_received_at) as complaint_received_at,
+    max(dob_run_date) as last_reported_at
+from {{ ref('stg_stalled_construction') }}
+group by bin, borough, house_number, street_name, complaint_number, bbl_key

--- a/dbt/models/intermediate/schema.yml
+++ b/dbt/models/intermediate/schema.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: int_stalled_construction
+    description: "Deduplicated stalled construction sites — one row per complaint + BIN"
+    columns:
+      - name: complaint_number
+        description: "DOB complaint number"
+        tests:
+          - not_null
+      - name: bin
+        description: "Building Identification Number"
+        tests:
+          - not_null

--- a/dbt/models/marts/mart_vacant_lots.sql
+++ b/dbt/models/marts/mart_vacant_lots.sql
@@ -1,6 +1,6 @@
 /*
-    Vacant lots enriched with building permit summary.
-    One row per vacant lot — permits are aggregated before joining to prevent fan-out.
+    Vacant lots enriched with permit and stalled construction data.
+    One row per vacant lot — tile-ready.
 */
 
 {{ config(materialized='table') }}
@@ -26,6 +26,17 @@ permit_summary as (
         date_diff(current_date(), max(issuance_date), year) as years_since_last_permit
     from {{ ref('stg_permits') }}
     group by bbl_key
+),
+
+stalled_summary as (
+    select
+        bbl_key,
+        count(*) as num_stalled_complaints,
+        min(complaint_received_at) as earliest_stalled_complaint,
+        max(last_reported_at) as latest_stalled_report
+    from {{ ref('int_stalled_construction') }}
+    where bbl_key is not null
+    group by bbl_key
 )
 
 select
@@ -33,7 +44,12 @@ select
     coalesce(p.num_permits, 0) as num_permits,
     p.latest_permit_date,
     p.latest_filing_date,
-    p.years_since_last_permit
+    p.years_since_last_permit,
+    coalesce(s.num_stalled_complaints, 0) as num_stalled_complaints,
+    s.earliest_stalled_complaint,
+    s.latest_stalled_report
 from vacant_lots v
 left join permit_summary p
     on v.bbl_key = p.bbl_key
+left join stalled_summary s
+    on v.bbl_key = s.bbl_key

--- a/dbt/models/marts/schema.yml
+++ b/dbt/models/marts/schema.yml
@@ -1,0 +1,19 @@
+version: 2
+
+models:
+  - name: mart_vacant_lots
+    description: "Vacant lots enriched with permit and stalled construction data. Tile-ready."
+    columns:
+      - name: bbl_key
+        description: "11-digit BBL string: borocode(1) + block(5) + lot(5)"
+        tests:
+          - not_null
+          - unique
+      - name: num_permits
+        description: "Total number of DOB permits for this lot"
+        tests:
+          - not_null
+      - name: num_stalled_complaints
+        description: "Total stalled construction complaints for this lot"
+        tests:
+          - not_null

--- a/dbt/models/staging/schema.yml
+++ b/dbt/models/staging/schema.yml
@@ -365,14 +365,10 @@ models:
         tests:
           - not_null
 
-  - name: stg_vacant_permits
-    description: "Vacant lots enriched with building permit summary (one row per lot)"
+  - name: stg_stalled_construction
+    description: "Staged DOB stalled construction sites with BIN→BBL mapping"
     columns:
-      - name: bbl_key
-        description: "11-digit BBL string"
-        tests:
-          - not_null
-      - name: num_permits
-        description: "Total number of permits for this lot"
+      - name: bin
+        description: "Building Identification Number"
         tests:
           - not_null

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -6,4 +6,8 @@ sources:
     schema: raw_dob
     tables:
       - name: permit_issuance
-        description: "NYC DOB Permit Issuance data, loaded as all STRING columns from CSV"
+        description: "NYC DOB Permit Issuance data"
+      - name: stalled_construction
+        description: "NYC DOB Stalled Construction Sites — complaints where construction has halted"
+      - name: building
+        description: "NYC Building Footprints — authoritative BIN to BBL mapping"

--- a/dbt/models/staging/stg_stalled_construction.sql
+++ b/dbt/models/staging/stg_stalled_construction.sql
@@ -1,0 +1,38 @@
+/*
+    Staging model for NYC DOB Stalled Construction Sites.
+    Uses BUILDING dataset for BIN → BBL mapping.
+*/
+
+with bin_to_bbl as (
+    select distinct
+        BIN as bin,
+        -- Map_Pluto_BBL is 10 digits: boro(1) + block(5) + lot(4)
+        -- Convert to 11 digits: boro(1) + block(5) + lot(5) to match PLUTO
+        concat(
+            substr(Map_Pluto_BBL, 1, 6),
+            lpad(substr(Map_Pluto_BBL, 7), 5, '0')
+        ) as bbl_key
+    from {{ source('raw_dob', 'building') }}
+    where BIN is not null
+      and Map_Pluto_BBL is not null
+),
+
+stalled as (
+    select
+        BIN as bin,
+        Borough_Name as borough,
+        House_Number as house_number,
+        Street_Name as street_name,
+        Complaint_Number as complaint_number,
+        safe.parse_timestamp('%Y %b %d %I:%M:%S %p', Date_Complaint_Received) as complaint_received_at,
+        safe.parse_timestamp('%Y %b %d %I:%M:%S %p', DOBRunDate) as dob_run_date
+    from {{ source('raw_dob', 'stalled_construction') }}
+    where BIN is not null
+)
+
+select
+    s.*,
+    b.bbl_key
+from stalled s
+left join bin_to_bbl b
+    on s.bin = b.bin


### PR DESCRIPTION
Adds DOB Stalled Construction Sites as a second data source alongside permits, and combines both into a single mart_vacant_lots model that's tile-ready.

### Changes
- BQ load targets and schemas for stalled construction and building datasets
- stg_stalled_construction: stages stalled sites with BIN→BBL mapping via BUILDING dataset
- int_stalled_construction: deduplicates daily snapshots to one row per complaint + BIN
- mart_vacant_lots: replaces stg_vacant_permits, enriches vacant lots with both permit and stalled construction summaries

### Data notes

- Stalled construction sites only have BIN (not BBL), so we use the NYC BUILDING dataset to map BIN→BBL
- The mart produces one row per vacant lot with permit counts, dates, and stalled complaint counts