### PR TITLE
Make stg_permits incremental with filing_date lookback

### DIFF
--- a/dbt/macros/bbl_key.sql
+++ b/dbt/macros/bbl_key.sql
@@ -1,0 +1,18 @@
+-- BBL key: 11-digit string {borocode 1}{block 5}{lot 5}
+
+{% macro bbl_key_from_parts(borocode, block, lot) %}
+concat(
+    cast({{ borocode }} as string),
+    lpad(cast({{ block }} as string), 5, '0'),
+    lpad(cast({{ lot }} as string), 5, '0')
+)
+{% endmacro %}
+
+-- Map_Pluto_BBL is 10 digits: boro(1) + block(5) + lot(4)
+-- Convert to 11 digits: boro(1) + block(5) + lot(5) to match PLUTO
+{% macro bbl_key_from_pluto_bbl(pluto_bbl) %}
+concat(
+    substr({{ pluto_bbl }}, 1, 6),
+    lpad(substr({{ pluto_bbl }}, 7), 5, '0')
+)
+{% endmacro %}

--- a/dbt/models/marts/mart_vacant_lots.sql
+++ b/dbt/models/marts/mart_vacant_lots.sql
@@ -8,11 +8,7 @@
 with vacant_lots as (
     select
         *,
-        concat(
-            cast(borocode as string),
-            lpad(cast(block as string), 5, '0'),
-            lpad(cast(lot as string), 5, '0')
-        ) as bbl_key
+        {{ bbl_key_from_parts('borocode', 'block', 'lot') }} as bbl_key
     from {{ ref('stg_vacant') }}
     where version = (select max(version) from {{ ref('stg_vacant') }})
 ),

--- a/dbt/models/staging/stg_permits.sql
+++ b/dbt/models/staging/stg_permits.sql
@@ -1,9 +1,20 @@
 /*
     Staging model for NYC DOB permit issuance data.
     Constructs a 10-digit BBL key for joining to PLUTO data.
+
+    Incremental: on subsequent runs, only processes permits filed
+    after the latest filing_date already in the table.
 */
 
+{{ config(
+    materialized='incremental',
+    unique_key='permit_key'
+) }}
+
 select
+    -- Unique key for deduplication
+    concat(Job_No, '-', Job_doc_No) as permit_key,
+
     -- Construct BBL key: {borocode 1}{block 5}{lot 5}
     concat(
         case BOROUGH
@@ -35,3 +46,11 @@ from {{ source('raw_dob', 'permit_issuance') }}
 where BOROUGH is not null
   and Block is not null
   and Lot is not null
+
+{% if is_incremental() %}
+  -- Only process rows newer than what we already have
+  and coalesce(
+    safe.parse_date('%m/%d/%Y', Filing_Date),
+    safe.parse_date('%Y-%m-%d', Filing_Date)
+  ) > (select max(filing_date) from {{ this }})
+{% endif %}

--- a/dbt/models/staging/stg_stalled_construction.sql
+++ b/dbt/models/staging/stg_stalled_construction.sql
@@ -6,12 +6,7 @@
 with bin_to_bbl as (
     select distinct
         BIN as bin,
-        -- Map_Pluto_BBL is 10 digits: boro(1) + block(5) + lot(4)
-        -- Convert to 11 digits: boro(1) + block(5) + lot(5) to match PLUTO
-        concat(
-            substr(Map_Pluto_BBL, 1, 6),
-            lpad(substr(Map_Pluto_BBL, 7), 5, '0')
-        ) as bbl_key
+        {{ bbl_key_from_pluto_bbl('Map_Pluto_BBL') }} as bbl_key
     from {{ source('raw_dob', 'building') }}
     where BIN is not null
       and Map_Pluto_BBL is not null


### PR DESCRIPTION
Stacked on #24 

`[CREATE TABLE (4.0m rows, 413.0 MiB processed) in 4.83s]`
becomes
`[MERGE (0.0 rows, 761.3 MiB processed) in 2.99s]`
Scans more data due to scanning the target table.