### PR TITLE
Add enriched vacant lot tile generation from BigQuery

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 GOOGLE_MAPS_API_KEY=AIzaSyD1znc516EcTgLnyQX3RvwVH4MlvVAQgPQ
+TILE_CDN_URL=https://cdn.empty.nyc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,8 +12,7 @@ on:
 env:
   REGISTRY: ghcr.io
 
-permissions:
-  packages: write
+permissions: write-all
 
 jobs:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,7 +32,7 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ github.repository_owner }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push tippecanoe image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,8 @@ on:
 env:
   REGISTRY: ghcr.io
 
-permissions: write-all
+permissions:
+  packages: write
 
 jobs:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,7 +32,7 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push tippecanoe image

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,13 @@ tiles.from_bq:
 	./build/json_to_geojsonl.sh tiles/lots.json tiles/lots.geojsonl
 	./build/geojson_to_pmtile.sh lots.geojsonl lots.pmtiles lots
 
+tiles.vacant_bq:
+	@test -n "$(BQ_DATASET)" || (echo "Error: BQ_DATASET is required. Usage: make tiles.vacant_bq BQ_DATASET=<your_dataset>" && exit 1)
+	mkdir -p tiles
+	BQ_DATASET=$(BQ_DATASET) ./build/pull_bigquery_data_for_tiles.sh build/vacant_lots_from_bq.sql > tiles/vacant.json
+	./build/json_to_geojsonl.sh tiles/vacant.json tiles/vacant.geojsonl
+	./build/geojson_to_pmtile.sh vacant.geojsonl vacant.pmtiles vacant
+
 ## BigQuery data loading
 ## Usage: make bq.load.permits CSV=local/data/DOB_Permit_Issuance.csv
 

--- a/build/geojson_to_pmtile.sh
+++ b/build/geojson_to_pmtile.sh
@@ -4,6 +4,7 @@ set -e
 GEOJSON_FILE_NAME=$1
 PMTILE_FILE_NAME=$2
 LAYER_NAME=$3
+CONTAINER_CMD="${CONTAINER_CMD:-docker}"
 CMD="tippecanoe \
     -f \
     -zg \
@@ -15,6 +16,6 @@ CMD="tippecanoe \
     /usr/local/tiles/$GEOJSON_FILE_NAME"
 IMG_TAG="ghcr.io/adrianparsons/tippecanoe:latest"
 
-docker run --rm \
+$CONTAINER_CMD run --rm \
     --mount type=bind,source="$(pwd)"/tiles,target=/usr/local/tiles/ \
     $IMG_TAG bash -c "$CMD"

--- a/build/pull_bigquery_data_for_tiles.sh
+++ b/build/pull_bigquery_data_for_tiles.sh
@@ -4,4 +4,4 @@ set -e
 
 QUERY_FILE=$1
 
-bq query --use_legacy_sql=false --max_rows=999999 --format=json < $QUERY_FILE
+envsubst < $QUERY_FILE | bq query --use_legacy_sql=false --max_rows=999999 --format=json

--- a/build/vacant_lots_from_bq.sql
+++ b/build/vacant_lots_from_bq.sql
@@ -1,0 +1,18 @@
+select
+    bbl_key as BBL,
+    address as Address,
+    ownername as OwnerName,
+    cast(borocode as string) as BoroCode,
+    cast(block as string) as Block,
+    cast(lot as string) as Lot,
+    lotarea as LotArea,
+    latitude as Latitude,
+    longitude as Longitude,
+    zonedist1 as ZoneDist1,
+    num_permits,
+    latest_permit_date,
+    years_since_last_permit,
+    num_stalled_complaints,
+    st_asgeojson(geometry) as geometry
+from `empty-lots.${BQ_DATASET}.mart_vacant_lots`
+where geometry is not null

--- a/dbt/models/marts/mart_vacant_lots.sql
+++ b/dbt/models/marts/mart_vacant_lots.sql
@@ -13,6 +13,11 @@ with vacant_lots as (
     where version = (select max(version) from {{ ref('stg_vacant') }})
 ),
 
+geometry as (
+    select bbl, geometry
+    from {{ source('nyc_pluto_historical', 'stg_geometry') }}
+),
+
 permit_summary as (
     select
         bbl_key,
@@ -37,6 +42,7 @@ stalled_summary as (
 
 select
     v.*,
+    g.geometry,
     coalesce(p.num_permits, 0) as num_permits,
     p.latest_permit_date,
     p.latest_filing_date,
@@ -45,6 +51,8 @@ select
     s.earliest_stalled_complaint,
     s.latest_stalled_report
 from vacant_lots v
+left join geometry g
+    on v.bbl = g.bbl
 left join permit_summary p
     on v.bbl_key = p.bbl_key
 left join stalled_summary s

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -11,3 +11,10 @@ sources:
         description: "NYC DOB Stalled Construction Sites — complaints where construction has halted"
       - name: building
         description: "NYC Building Footprints — authoritative BIN to BBL mapping"
+
+  - name: nyc_pluto_historical
+    database: empty-lots
+    schema: nyc_pluto_historical
+    tables:
+      - name: stg_geometry
+        description: "Lot polygon geometry (GEOGRAPHY) keyed by BBL (float64)"

--- a/src/infoWindow.ts
+++ b/src/infoWindow.ts
@@ -16,12 +16,14 @@ class InfoWindow extends HTMLElement {
   }
 
   private render() {
-    const { address, ownername, lotArea, zolaLink, bbl } = this._data;
+    const { address, ownername, lotArea, zolaLink, bbl, numPermits, latestPermitDate, numStalledComplaints } = this._data;
     this.innerHTML = `
       <div>
         <h3 style="margin-top: 0">${address || ''}</h3>
         <p>Owner: ${ownername || ''}</p>
         <p>${lotArea || ''} square feet</p>
+        ${numPermits > 0 ? `<p>${numPermits} DOB permit${numPermits > 1 ? 's' : ''}${latestPermitDate ? ` (latest: ${latestPermitDate})` : ''}</p>` : ''}
+        ${numStalledComplaints > 0 ? `<p>${numStalledComplaints} stalled construction complaint${numStalledComplaints > 1 ? 's' : ''}</p>` : ''}
         ${zolaLink ? `<p><a href="${zolaLink}" target="_blank">ZoLa ⤴</a></p>` : ''}
         <p>${bbl}</p>
       </div>

--- a/src/map.ts
+++ b/src/map.ts
@@ -147,6 +147,9 @@ export async function initMap(): Promise<Map>{
         ownername: props.OwnerName,
         lotArea: Number(props.LotArea).toLocaleString(),
         zolaLink: `https://zola.planning.nyc.gov/l/lot/${props.BoroCode}/${props.Block}/${props.Lot}`,
+        numPermits: Number(props.num_permits) || 0,
+        latestPermitDate: props.latest_permit_date,
+        numStalledComplaints: Number(props.num_stalled_complaints) || 0,
       }
 
       map.easeTo({center: [lng, lat]})

--- a/src/map.ts
+++ b/src/map.ts
@@ -37,21 +37,23 @@ export async function initMap(): Promise<Map>{
       })
     );
 
+    const tileBaseUrl = process.env.TILE_CDN_URL || 'https://cdn.empty.nyc';
+
     map.addSource('vacant', {
       type: 'vector',
-      url: 'pmtiles://https://cdn.empty.nyc/vacant.pmtiles',
+      url: `pmtiles://${tileBaseUrl}/vacant.pmtiles`,
       promoteId: 'BBL'
     });
 
     map.addSource('parking', {
       type: 'vector',
-      url: 'pmtiles://https://cdn.empty.nyc/parking.pmtiles',
+      url: `pmtiles://${tileBaseUrl}/parking.pmtiles`,
       promoteId: 'BBL'
     });
 
     map.addSource('alllots', {
       type: 'vector',
-      url: 'pmtiles://https://cdn.empty.nyc/alllotsnyc.pmtiles',
+      url: `pmtiles://${tileBaseUrl}/alllotsnyc.pmtiles`,
     });
 
     map.addLayer({


### PR DESCRIPTION
Stacked on #25 

Generates vacant lot tiles from `mart_vacant_lots` instead of the shapefile pipeline. The mart includes geometry (joined from `stg_geometry`), permit counts, and stalled construction data. The map info popup has been updated with the permit/stalled data.

The tile extraction SQL uses `envsubst` for the dataset name so it works against development dbt targets as well as prod.

Also adds a configurable tile CDN URL (via `TILE_CDN_URL` env var) for local development.

<img width="298" height="242" alt="2026-02-17_01-05" src="https://github.com/user-attachments/assets/c996d11a-298d-4d52-bf5d-2a611127e2f6" />
