### PR TITLE
Deploy static assets to static.empty.nyc

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GCP_BUCKET_WEB: 'nyc-lots-web'
-  GCP_PROJECT: 'empty-lots'
+  GCP_BUCKET_WEB: ${{ vars.GCP_BUCKET_WEB }}
+  GCP_PROJECT: ${{ vars.GCP_PROJECT }}
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   URL_PREFIX: ${{ github.head_ref || github.ref_name }}
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -39,7 +39,7 @@ jobs:
 
     - run: npm ci
     - run: npm audit --audit-level=moderate
-    - run: PUBLIC_URL=${{ env.GCP_BUCKET_WEB }}/${{ env.URL_PREFIX }} make build.prod
+    - run: PUBLIC_URL=${{ env.URL_PREFIX }} make build.prod
     - name: Create zip file of static production site
       uses: actions/upload-artifact@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 bucket = gs://nyc-lots-tiles
 gcproject = empty-lots
 
-.PHONY: clean watch tiles.cors deploy build tiles_from_bq
+.PHONY: clean watch tiles.cors build tiles_from_bq
 
 clean:
 	rm -rf dist/*
@@ -22,14 +22,6 @@ build.prod:
 watch:
 	cp -r static dist/
 	npx parcel
-
-# rsync the dist directory on a remote server, ignore dotfiles
-deploy: clean build.prod
-	rsync -e "ssh -i ~/.ssh/id_ed25519" \
-	-av --delete dist/ \
-	amp926@adrianparsons.com:/home/amp926/emptylots.adrianparsons.com \
-	--exclude="\.*" \
-	--verbose
 
 tiles.all_lots:
 	./build/query_to_geojson.sh MapPLUTO build/all_lots.sql

--- a/terraform/loadbalancer.tf
+++ b/terraform/loadbalancer.tf
@@ -5,9 +5,26 @@ resource "google_compute_backend_bucket" "emptynyc" {
   compression_mode = "DISABLED"
 }
 
+resource "google_compute_backend_bucket" "emptynyc_web" {
+  name             = "emptynyc-web"
+  bucket_name      = google_storage_bucket.nyc_lots_web.name
+  enable_cdn       = false
+  compression_mode = "DISABLED"
+}
+
 resource "google_compute_url_map" "nyc_lots_tiles" {
   name            = "nyc-lots-tiles"
   default_service = google_compute_backend_bucket.emptynyc.self_link
+
+  host_rule {
+    hosts        = ["static.${var.domain}"]
+    path_matcher = "static"
+  }
+
+  path_matcher {
+    name            = "static"
+    default_service = google_compute_backend_bucket.emptynyc_web.self_link
+  }
 }
 
 resource "google_compute_managed_ssl_certificate" "cdn_emptynyc" {
@@ -18,17 +35,28 @@ resource "google_compute_managed_ssl_certificate" "cdn_emptynyc" {
   }
 }
 
+resource "google_compute_managed_ssl_certificate" "static_emptynyc" {
+  name = "static-emptynyc"
+  type = "MANAGED"
+  managed {
+    domains = ["static.${var.domain}"]
+  }
+}
+
 resource "google_compute_target_http_proxy" "nyc_lots_tiles" {
   name    = "nyc-lots-tiles-target-proxy"
   url_map = google_compute_url_map.nyc_lots_tiles.self_link
 }
 
 resource "google_compute_target_https_proxy" "nyc_lots_tiles" {
-  name             = "nyc-lots-tiles-target-proxy-2"
-  url_map          = google_compute_url_map.nyc_lots_tiles.self_link
-  ssl_certificates = [google_compute_managed_ssl_certificate.cdn_emptynyc.self_link]
-  quic_override    = "NONE"
-  tls_early_data   = "DISABLED"
+  name    = "nyc-lots-tiles-target-proxy-2"
+  url_map = google_compute_url_map.nyc_lots_tiles.self_link
+  ssl_certificates = [
+    google_compute_managed_ssl_certificate.cdn_emptynyc.self_link,
+    google_compute_managed_ssl_certificate.static_emptynyc.self_link,
+  ]
+  quic_override  = "NONE"
+  tls_early_data = "DISABLED"
 }
 
 resource "google_compute_global_forwarding_rule" "cdn_empty_frontend" {

--- a/terraform/loadbalancer.tf
+++ b/terraform/loadbalancer.tf
@@ -21,9 +21,41 @@ resource "google_compute_url_map" "nyc_lots_tiles" {
     path_matcher = "static"
   }
 
+  host_rule {
+    hosts        = [var.domain]
+    path_matcher = "apex"
+  }
+
+  host_rule {
+    hosts        = ["www.${var.domain}"]
+    path_matcher = "www-redirect"
+  }
+
   path_matcher {
     name            = "static"
     default_service = google_compute_backend_bucket.emptynyc_web.self_link
+  }
+
+  path_matcher {
+    name            = "apex"
+    default_service = google_compute_backend_bucket.emptynyc_web.self_link
+
+    default_route_action {
+      url_rewrite {
+        path_prefix_rewrite = "/main/"
+      }
+    }
+  }
+
+  path_matcher {
+    name = "www-redirect"
+
+    default_url_redirect {
+      host_redirect          = var.domain
+      redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+      strip_query            = false
+      https_redirect         = true
+    }
   }
 }
 
@@ -43,6 +75,14 @@ resource "google_compute_managed_ssl_certificate" "static_emptynyc" {
   }
 }
 
+resource "google_compute_managed_ssl_certificate" "apex_emptynyc" {
+  name = "apex-emptynyc"
+  type = "MANAGED"
+  managed {
+    domains = [var.domain, "www.${var.domain}"]
+  }
+}
+
 resource "google_compute_target_http_proxy" "nyc_lots_tiles" {
   name    = "nyc-lots-tiles-target-proxy"
   url_map = google_compute_url_map.nyc_lots_tiles.self_link
@@ -54,6 +94,7 @@ resource "google_compute_target_https_proxy" "nyc_lots_tiles" {
   ssl_certificates = [
     google_compute_managed_ssl_certificate.cdn_emptynyc.self_link,
     google_compute_managed_ssl_certificate.static_emptynyc.self_link,
+    google_compute_managed_ssl_certificate.apex_emptynyc.self_link,
   ]
   quic_override  = "NONE"
   tls_early_data = "DISABLED"

--- a/terraform/loadbalancer.tf
+++ b/terraform/loadbalancer.tf
@@ -22,7 +22,7 @@ resource "google_compute_url_map" "nyc_lots_tiles" {
   }
 
   host_rule {
-    hosts        = [var.domain]
+    hosts        = [var.domain, "prod.${var.domain}"]
     path_matcher = "apex"
   }
 
@@ -83,6 +83,14 @@ resource "google_compute_managed_ssl_certificate" "apex_emptynyc" {
   }
 }
 
+resource "google_compute_managed_ssl_certificate" "prod_emptynyc" {
+  name = "prod-emptynyc"
+  type = "MANAGED"
+  managed {
+    domains = ["prod.${var.domain}"]
+  }
+}
+
 resource "google_compute_target_http_proxy" "nyc_lots_tiles" {
   name    = "nyc-lots-tiles-target-proxy"
   url_map = google_compute_url_map.nyc_lots_tiles.self_link
@@ -95,6 +103,7 @@ resource "google_compute_target_https_proxy" "nyc_lots_tiles" {
     google_compute_managed_ssl_certificate.cdn_emptynyc.self_link,
     google_compute_managed_ssl_certificate.static_emptynyc.self_link,
     google_compute_managed_ssl_certificate.apex_emptynyc.self_link,
+    google_compute_managed_ssl_certificate.prod_emptynyc.self_link,
   ]
   quic_override  = "NONE"
   tls_early_data = "DISABLED"

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -30,13 +30,6 @@ resource "google_storage_bucket" "nyc_lots_tiles" {
   }
 
   cors {
-    origin          = ["https://storage.googleapis.com/"]
-    method          = ["GET"]
-    response_header = ["Content-Type"]
-    max_age_seconds = 0
-  }
-
-  cors {
     origin          = ["https://${var.domain}"]
     method          = ["GET"]
     response_header = ["Content-Type"]
@@ -45,6 +38,13 @@ resource "google_storage_bucket" "nyc_lots_tiles" {
 
   cors {
     origin          = ["https://static.${var.domain}"]
+    method          = ["GET"]
+    response_header = ["Content-Type"]
+    max_age_seconds = 3600
+  }
+
+  cors {
+    origin          = ["https://prod.${var.domain}"]
     method          = ["GET"]
     response_header = ["Content-Type"]
     max_age_seconds = 3600

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -39,6 +39,13 @@ resource "google_storage_bucket" "nyc_lots_tiles" {
     max_age_seconds = 3600
   }
 
+  cors {
+    origin          = ["https://static.${var.domain}"]
+    method          = ["GET"]
+    response_header = ["Content-Type"]
+    max_age_seconds = 3600
+  }
+
   lifecycle {
     prevent_destroy = true
   }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -2,6 +2,10 @@ resource "google_storage_bucket" "nyc_lots_web" {
   name     = "${var.bucket_prefix}-web"
   location = var.region
 
+  website {
+    main_page_suffix = "index.html"
+  }
+
   lifecycle {
     prevent_destroy = true
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,7 +28,7 @@ variable "org_id" {
 }
 
 variable "domain" {
-  description = "Primary domain. CDN is served at cdn.<domain>."
+  description = "Primary domain. Tiles CDN is served at cdn.<domain>; static frontend is served at static.<domain>."
   type        = string
 }
 


### PR DESCRIPTION
This updates existing Terraform configs to deploy html/css/js assets to static.empty.nyc. This happens for every branch: for example this pull request's build will be available at: https://static.empty.nyc/amp/static-subdomain

Part of a larger effort to let GCP handle all DNS routing and to serve the base empty.nyc domain from GCP infrastructure.