### PR TITLE
Fix loadbalancer routing issue

### DIFF
--- a/terraform/loadbalancer.tf
+++ b/terraform/loadbalancer.tf
@@ -42,7 +42,7 @@ resource "google_compute_url_map" "nyc_lots_tiles" {
 
     default_route_action {
       url_rewrite {
-        path_prefix_rewrite = "/main/"
+        path_prefix_rewrite = "/main"
       }
     }
   }


### PR DESCRIPTION
so that prod.empty.nyc points to the `main` directory of the bucket.