### PR TITLE
Fix production deployment builds

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,6 +3,7 @@ name: Build and deploy static Frontend with Node.js
 on:
   push:
     branches: [ "**" ]
+    tags: [ "**" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,8 +2,10 @@ name: Build and deploy static Frontend with Node.js
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "main" ]
     tags: [ "**" ]
+  pull_request:
+    branches: [ "main" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -39,7 +39,10 @@ jobs:
 
     - run: npm ci
     - run: npm audit --audit-level=moderate
-    - run: PUBLIC_URL=${{ env.URL_PREFIX }} make build.prod
+    - if: github.ref_name == 'main'
+      run: make build.prod
+    - if: github.ref_name != 'main'
+      run: PUBLIC_URL=${{ env.URL_PREFIX }} make build.prod
     - name: Create zip file of static production site
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -39,10 +39,9 @@ jobs:
 
     - run: npm ci
     - run: npm audit --audit-level=moderate
-    - if: github.ref_name == 'main'
-      run: make build.prod
-    - if: github.ref_name != 'main'
-      run: PUBLIC_URL=${{ env.URL_PREFIX }} make build.prod
+    - run: make build.prod
+      env:
+        PUBLIC_URL: ${{ (github.ref_name == 'main' || github.ref_type == 'tag' || github.event_name == 'deployment') && '' || env.URL_PREFIX }}
     - name: Create zip file of static production site
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Where PR builds are served from static.empty.nyc/branch-name, production deployments should be served from prod.empty.nyc (and eventually empty.nyc). Update gh actions to reflect this, and to handle tagged releases and "deployments" (not sure how those work yet) similarly.