### PR TITLE
Add deployment graphic to architecture diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,3 +15,14 @@ graph TB
     GMapsAPI -->|Returns| StreetView
     StreetView -->|Display| FrontEnd
 ```
+
+## Build
+
+```mermaid
+flowchart LR
+    A["Build images<br/>(gdal, tippecanoe)"] --> B[("ghcr.io image registry")]
+    C["Build frontend<br/>(parcel)"] --> D[("GCP bucket")]
+    B --> E["Generate map tiles with images"]
+    E --> F[("GCP bucket")]
+```
+


### PR DESCRIPTION
This is the deployment flow that doesn't use bigquery, but is currently live.