### PR TITLE
Move to google cloud managed DNS

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,31 @@
+resource "google_dns_managed_zone" "empty_nyc" {
+  name        = "empty-nyc"
+  dns_name    = "${var.domain}."
+  description = "Public zone for ${var.domain}"
+}
+
+resource "google_dns_record_set" "apex_a" {
+  name         = "${var.domain}."
+  managed_zone = google_dns_managed_zone.empty_nyc.name
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_global_forwarding_rule.cdn_empty_frontend.ip_address]
+}
+
+resource "google_dns_record_set" "subdomain_a" {
+  for_each = toset(["www", "prod", "cdn", "static"])
+
+  name         = "${each.key}.${var.domain}."
+  managed_zone = google_dns_managed_zone.empty_nyc.name
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_global_forwarding_rule.cdn_empty_frontend.ip_address]
+}
+
+resource "google_dns_record_set" "atproto_txt" {
+  name         = "_atproto.${var.domain}."
+  managed_zone = google_dns_managed_zone.empty_nyc.name
+  type         = "TXT"
+  ttl          = 3600
+  rrdatas      = ["\"did=did:plc:5wmwpdxigril7gqurm7igwwn\""]
+}

--- a/terraform/loadbalancer.tf
+++ b/terraform/loadbalancer.tf
@@ -76,10 +76,14 @@ resource "google_compute_managed_ssl_certificate" "static_emptynyc" {
 }
 
 resource "google_compute_managed_ssl_certificate" "apex_emptynyc" {
-  name = "apex-emptynyc"
+  name = "apex-emptynyc-2"
   type = "MANAGED"
   managed {
     domains = [var.domain, "www.${var.domain}"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "dns_nameservers" {
+  description = "Point your registrar at these nameservers to activate Cloud DNS for empty.nyc."
+  value       = google_dns_managed_zone.empty_nyc.name_servers
+}


### PR DESCRIPTION
Some Terraform updates.
 - empty.nyc DNS is now managed by google cloud
 - root-level https://empty.nyc will be served from a gcp bucket (load balancer was already in place)