### PR TITLE
Update geometry data pipeline

### DIFF
--- a/build/load_geojson_to_bigquery.sh
+++ b/build/load_geojson_to_bigquery.sh
@@ -3,10 +3,19 @@
 # Load MapPLUTO lot geometry (GEOGRAPHY, keyed by BBL) into raw_pluto from the
 # vendored GeoJSONL snapshot.   make bq.load.geometry
 
-set -e
+set -eou pipefail
 
 : "${RAW_BUCKET:?set RAW_BUCKET (e.g. run via 'make bq.load.geometry')}"
 : "${GCP_PROJECT:?set GCP_PROJECT (e.g. run via 'make bq.load.geometry')}"
 : "${PLUTO_DATASET:?set PLUTO_DATASET (e.g. run via 'make bq.load.geometry')}"
+here="$(cd "$(dirname "$0")" && pwd)"
+schema="${here}/schemas/mappluto.json"
 
-bq load --ignore_unknown_values --source_format=NEWLINE_DELIMITED_JSON --json_extension=GEOJSON --schema="geometry:GEOGRAPHY,BBL:FLOAT64" --replace "${GCP_PROJECT}:${PLUTO_DATASET}.mappluto_geometry" "${RAW_BUCKET}/pluto/MapPLUTO.geojsonl"
+bq load \
+  --ignore_unknown_values \
+  --source_format=NEWLINE_DELIMITED_JSON \
+  --json_extension=GEOJSON \
+  --schema="${schema}" \
+  --replace \
+  "${GCP_PROJECT}:${PLUTO_DATASET}.mappluto_geometry" \
+  "${RAW_BUCKET}/pluto/MapPLUTO.geojsonl"

--- a/build/schemas/mappluto.json
+++ b/build/schemas/mappluto.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "BBL",
+    "type": "STRING"
+  },
+  {
+    "name": "geometry",
+    "type": "STRING"
+  }
+]

--- a/dbt/models/marts/mart_parking_lots.sql
+++ b/dbt/models/marts/mart_parking_lots.sql
@@ -13,7 +13,7 @@ with parking as (
 
 geometry as (
     select bbl, geometry
-    from {{ source('nyc_pluto_historical', 'stg_geometry') }}
+    from {{ ref('stg_geometry') }}
 )
 
 select

--- a/dbt/models/marts/mart_vacant_lots.sql
+++ b/dbt/models/marts/mart_vacant_lots.sql
@@ -15,7 +15,7 @@ with vacant_lots as (
 
 geometry as (
     select bbl, geometry
-    from {{ source('nyc_pluto_historical', 'stg_geometry') }}
+    from {{ ref('stg_geometry') }}
 ),
 
 permit_summary as (

--- a/dbt/models/staging/schema.yml
+++ b/dbt/models/staging/schema.yml
@@ -349,6 +349,16 @@ models:
         description: "E-designation date"
         data_type: string
 
+  - name: stg_geometry
+    description: "Geometry (polygons) for each lot"
+    columns:
+      - name: BBL
+        description: "Borough-Block-Lot identifier (concatenated)"
+        data_type: float64
+      - name: geometry
+        description: "Geometry column (spatial data)"
+        data_type: geography
+
   - name: stg_vacant
     description: "Staging model for NYC PLUTO lots data with all columns and proper data types"
     columns: *pluto_base_columns

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -74,14 +74,3 @@ sources:
             publisher: "NYC Department of City Planning"
             source_url: "https://www.nyc.gov/content/planning/pages/resources/datasets/mappluto-pluto-change"
             releases: "18v2_1, 19v2, 20v8, 21v3, 22v3, 23v3_1, 24v4_1, 25v3"
-
-      - name: stg_geometry
-        description: >
-          Lot polygon geometry (GEOGRAPHY) keyed by BBL (float64), from
-          MapPLUTO.geojsonl. Loaded via build/load_geojson_to_bigquery.sh
-          (NEWLINE_DELIMITED_JSON / GEOJSON).
-        config:
-          meta:
-            publisher: "NYC Department of City Planning"
-            source_url: "https://www.nyc.gov/content/planning/pages/resources/datasets/mappluto-pluto-change"
-            loaded_by: "build/load_geojson_to_bigquery.sh"

--- a/dbt/models/staging/stg_geometry.sql
+++ b/dbt/models/staging/stg_geometry.sql
@@ -1,2 +1,6 @@
-select *
+{{ config(materialized='table') }}
+
+select
+    safe_cast(BBL as float64 ) as BBL,
+    st_geogfromgeojson(geometry, make_valid => true) as geometry,
 from {{ source('raw_pluto', 'mappluto_geometry') }}

--- a/dbt/models/staging/stg_geometry.sql
+++ b/dbt/models/staging/stg_geometry.sql
@@ -1,6 +1,6 @@
 {{ config(materialized='table') }}
 
 select
-    safe_cast(BBL as float64 ) as BBL,
+    safe_cast(BBL as float64 ) as bbl,
     st_geogfromgeojson(geometry, make_valid => true) as geometry,
 from {{ source('raw_pluto', 'mappluto_geometry') }}

--- a/dbt/models/staging/stg_geometry.sql
+++ b/dbt/models/staging/stg_geometry.sql
@@ -1,0 +1,2 @@
+select *
+from {{ source('raw_pluto', 'mappluto_geometry') }}


### PR DESCRIPTION
This clarifies where the NYC plot geometry data (that we use to generate map tiles) comes from. Creates an `stg_geometry` model in dbt with a clearer lineage back to raw data.