### PR TITLE
add ownername to vacancy table columns

### DIFF
--- a/dbt/models/staging/stg_vacancy.sql
+++ b/dbt/models/staging/stg_vacancy.sql
@@ -4,6 +4,7 @@
 
 select bbl,
 cast(bbl as string) as bbl_key,
+ownername,
 range(
   date( concat('20', substring(version, 0, 2), '-1-1') ),
   date_add(date( concat('20', substring(version, 0, 2), '-1-1')), interval 1 year)

--- a/dbt/models/staging/stg_vacant_range.sql
+++ b/dbt/models/staging/stg_vacant_range.sql
@@ -5,6 +5,7 @@
 
 select
   bbl_key,
+  ownername,
   vacant_year,
   session_range
 from range_sessionize(


### PR DESCRIPTION
ownername column now passes through `stg_vacancy` and `stg_vacant_range.sql` models