### PR TITLE
Fix the dbt DAG, move some SQL from scripts to dbt

### DIFF
--- a/build/all_lots_with_vacancy_data.sql
+++ b/build/all_lots_with_vacancy_data.sql
@@ -1,30 +1,4 @@
-with has_vacancy as (
-    select *
-    from `empty-lots`.`nyc_pluto_historical`.`stg_vacant_range`
-    where range_end(session_range) = '2026-01-01'
-),
 
-vacancy_by_bbl as (
-    select distinct
-        bbl_key,
-        range_start(session_range) as range_start
-    from has_vacancy
-),
-
-versions as (
-    select distinct
-        version
-    from `nyc_pluto_historical.stg_lots_filtered`
-)
-
-select
-    filtered.*,
-    range_start as vacant_since,
-    st_asgeojson(geo.geometry) as geometry
-from vacancy_by_bbl
-right join `empty-lots`.`nyc_pluto_historical.stg_lots_filtered` as filtered
-    on bbl_key = cast(filtered.bbl as string)
-join `empty-lots.nyc_pluto_historical.stg_geometry` as geo
-    on filtered.bbl = geo.bbl
-where filtered.version = (select max(version) from versions)
-    and landuse = '11'
+select *
+from `empty-lots`.`nyc_pluto_historical`.`mart_vacant_lots`
+where geometry is not null

--- a/build/parking_lots_from_bq.sql
+++ b/build/parking_lots_from_bq.sql
@@ -1,6 +1,4 @@
 select
-    parking.* except(geometry),
-    st_asgeojson(geometry) as geometry
+    *
 from `empty-lots.nyc_pluto_historical.mart_parking_lots` as parking
 where geometry is not null
-

--- a/build/parking_lots_from_bq.sql
+++ b/build/parking_lots_from_bq.sql
@@ -1,4 +1,4 @@
 select
     *
 from `empty-lots.nyc_pluto_historical.mart_parking_lots` as parking
-where geometry is not null
+where parking.geometry is not null

--- a/dbt/models/intermediate/int_vacant_since.sql
+++ b/dbt/models/intermediate/int_vacant_since.sql
@@ -1,0 +1,29 @@
+/*
+    For every vacant lot calculate how long it has been vacant
+*/
+
+with has_vacancy as (
+    select *
+    from from {{ ref('stg_vacant_range') }}
+    -- We want to get ranges from places that are *currently* vacant
+    where range_end(session_range) = max(range_end(session_range))
+),
+
+vacancy_by_bbl as (
+    select distinct
+        bbl_key,
+        range_start(session_range) as range_start
+    from has_vacancy
+),
+
+select
+    filtered.*,
+    range_start as vacant_since,
+    st_asgeojson(geo.geometry) as geometry
+from vacancy_by_bbl
+right join `empty-lots`.`nyc_pluto_historical.stg_lots_filtered` as filtered
+    on bbl_key = cast(filtered.bbl as string)
+join `empty-lots.nyc_pluto_historical.stg_geometry` as geo
+    on filtered.bbl = geo.bbl
+where filtered.version = {{ current_pluto_version() }}
+    and landuse = '11'

--- a/dbt/models/intermediate/int_vacant_since.sql
+++ b/dbt/models/intermediate/int_vacant_since.sql
@@ -3,23 +3,18 @@
 */
 
 with has_vacancy as (
-    select *
-    from from {{ ref('stg_vacant_range') }}
-    -- We want to get ranges from places that are *currently* vacant
-    where range_end(session_range) = max(range_end(session_range))
-),
-
-vacancy_by_bbl as (
-    select distinct
+    select
         bbl_key,
-        range_start(session_range) as range_start
-    from has_vacancy
-),
+        vacant_year,
+        session_range
+    from {{ ref('stg_vacant_range') }}
+    -- We want to get ranges from places that are *currently* vacant
+    where range_end(session_range) = (
+        select max(range_end(vacant_year)) from {{ ref('stg_vacancy') }}
+    )
+)
 
-select
-    filtered.*,
-    range_start as vacant_since,
-from vacancy_by_bbl
-right join {{ ref('stg_vacant') }} as filtered
-    on bbl_key = cast(filtered.bbl as string)
-where filtered.version = {{ current_pluto_version() }}
+select distinct
+    bbl_key,
+    range_start(session_range) as vacant_since
+from has_vacancy

--- a/dbt/models/intermediate/int_vacant_since.sql
+++ b/dbt/models/intermediate/int_vacant_since.sql
@@ -19,11 +19,7 @@ vacancy_by_bbl as (
 select
     filtered.*,
     range_start as vacant_since,
-    st_asgeojson(geo.geometry) as geometry
 from vacancy_by_bbl
-right join `empty-lots`.`nyc_pluto_historical.stg_lots_filtered` as filtered
+right join {{ ref('stg_vacant') }} as filtered
     on bbl_key = cast(filtered.bbl as string)
-join `empty-lots.nyc_pluto_historical.stg_geometry` as geo
-    on filtered.bbl = geo.bbl
 where filtered.version = {{ current_pluto_version() }}
-    and landuse = '11'

--- a/dbt/models/marts/mart_parking_lots.sql
+++ b/dbt/models/marts/mart_parking_lots.sql
@@ -17,7 +17,7 @@ geometry as (
 )
 
 select
-    p.*,
+    p.* except (spdist3, zonedist4),
     g.geometry
 from parking p
 join geometry g on p.bbl = g.bbl

--- a/dbt/models/marts/mart_parking_lots.sql
+++ b/dbt/models/marts/mart_parking_lots.sql
@@ -18,6 +18,7 @@ geometry as (
 
 select
     p.* except (spdist3, zonedist4),
-    g.geometry
+    st_asgeojson(g.geometry) as geometry
 from parking p
-join geometry g on p.bbl = g.bbl
+join geometry g
+    on p.bbl = g.bbl

--- a/dbt/models/marts/mart_vacant_lots.sql
+++ b/dbt/models/marts/mart_vacant_lots.sql
@@ -36,7 +36,7 @@ stalled_summary as (
 )
 
 select
-    v.*,
+    v.* except (spdist3, zonedist4),
     vs.vacant_since,
     st_asgeojson(g.geometry) as geometry,
     coalesce(p.num_permits, 0) as num_permits,

--- a/dbt/models/marts/mart_vacant_lots.sql
+++ b/dbt/models/marts/mart_vacant_lots.sql
@@ -38,7 +38,7 @@ stalled_summary as (
 select
     v.*,
     vs.vacant_since,
-    g.geometry,
+    st_asgeojson(g.geometry) as geometry,
     coalesce(p.num_permits, 0) as num_permits,
     p.latest_permit_date,
     p.latest_filing_date,

--- a/dbt/models/marts/mart_vacant_lots.sql
+++ b/dbt/models/marts/mart_vacant_lots.sql
@@ -13,11 +13,6 @@ with vacant_lots as (
     where version = {{ current_pluto_version() }}
 ),
 
-geometry as (
-    select bbl, geometry
-    from {{ ref('stg_geometry') }}
-),
-
 permit_summary as (
     select
         bbl_key,
@@ -42,6 +37,7 @@ stalled_summary as (
 
 select
     v.*,
+    vs.vacant_since,
     g.geometry,
     coalesce(p.num_permits, 0) as num_permits,
     p.latest_permit_date,
@@ -51,9 +47,11 @@ select
     s.earliest_stalled_complaint,
     s.latest_stalled_report
 from vacant_lots v
-left join geometry g
+left join {{ ref('stg_geometry') }} g
     on v.bbl = g.bbl
 left join permit_summary p
     on v.bbl_key = p.bbl_key
 left join stalled_summary s
     on v.bbl_key = s.bbl_key
+left join {{ ref('int_vacant_since') }} vs
+    on v.bbl_key = vs.bbl_key

--- a/dbt/models/staging/schema.yml
+++ b/dbt/models/staging/schema.yml
@@ -269,9 +269,6 @@ models:
         description: "Tertiary special purpose district"
         data_type: string
 
-      - name: condono
-        description: "Condominium number"
-        data_type: int64
       - name: tract2010
         description: "2010 Census tract (full)"
         data_type: string
@@ -293,15 +290,8 @@ models:
         description: "Basement code"
         data_type: string
 
-      - name: geom
-        description: "Geometry column (spatial data)"
-        data_type: string
-
       - name: sanborn
         description: "Sanborn map reference"
-        data_type: string
-      - name: mappluto_f
-        description: "MapPLUTO flag"
         data_type: string
 
       # Flags and indicators
@@ -313,35 +303,6 @@ models:
         data_type: string
       - name: dcpedited
         description: "DCP edited flag"
-        data_type: string
-      - name: exemptland
-        description: "Exempt land value"
-        data_type: int64
-
-      # Removed in 2020
-      - name: rpaddate
-        description: "Real Property Assessment Database date"
-        data_type: string
-      - name: dcasdate
-        description: "Department of Citywide Administrative Services date"
-        data_type: string
-      - name: zoningdate
-        description: "Zoning date"
-        data_type: string
-      - name: landmkdate
-        description: "Landmark date"
-        data_type: string
-      - name: basempdate
-        description: "Base map date"
-        data_type: string
-      - name: masdate
-        description: "Mass Appraisal System date"
-        data_type: string
-      - name: polidate
-        description: "Police precinct date"
-        data_type: string
-      - name: edesigdate
-        description: "E-designation date"
         data_type: string
 
   - name: stg_geometry

--- a/dbt/models/staging/stg_geometry.sql
+++ b/dbt/models/staging/stg_geometry.sql
@@ -1,6 +1,6 @@
-{{ config(materialized='table') }}
-
 select
     safe_cast(BBL as float64 ) as bbl,
-    st_geogfromgeojson(geometry, make_valid => true) as geometry,
+    st_geogfromgeojson
+    st_geo(geometry, make_valid => true) as geometry,
 from {{ source('raw_pluto', 'mappluto_geometry') }}
+

--- a/dbt/models/staging/stg_geometry.sql
+++ b/dbt/models/staging/stg_geometry.sql
@@ -1,6 +1,5 @@
 select
     safe_cast(BBL as float64 ) as bbl,
-    st_geogfromgeojson
-    st_geo(geometry, make_valid => true) as geometry,
+    st_geogfromgeojson(geometry, make_valid => true) as geometry,
 from {{ source('raw_pluto', 'mappluto_geometry') }}
 

--- a/dbt/models/staging/stg_lots.sql
+++ b/dbt/models/staging/stg_lots.sql
@@ -92,28 +92,18 @@ select
     irrlotcode,
     lottype,
     bsmtcode,
-    safe_cast(condono as int64)     as condono,
     tract2010,
 
     -- Assessment and valuation
     safe_cast(assessland as float64) as assessland,
     safe_cast(assesstot as float64)  as assesstot,
     safe_cast(exempttot as float64)  as exempttot,
-    safe_cast(exemptland as int64)   as exemptland,
 
     -- Dates and history
     safe_cast(yearbuilt as int64)  as yearbuilt,
     safe_cast(yearalter1 as int64) as yearalter1,
     safe_cast(yearalter2 as int64) as yearalter2,
     appdate,
-    rpaddate,
-    dcasdate,
-    zoningdate,
-    landmkdate,
-    basempdate,
-    masdate,
-    polidate,
-    edesigdate,
 
     -- Historic and landmark
     histdist,
@@ -134,8 +124,6 @@ select
     safe_cast(appbbl as float64)   as appbbl,
     safe_cast(plutomapid as int64) as plutomapid,
     sanborn,
-    mappluto_f,
-    geom,
 
     -- Flags
     firm07_flag,

--- a/dbt/models/staging/stg_stalled_construction.sql
+++ b/dbt/models/staging/stg_stalled_construction.sql
@@ -19,8 +19,8 @@ stalled as (
         House_Number as house_number,
         Street_Name as street_name,
         Complaint_Number as complaint_number,
-        safe.parse_timestamp('%Y %b %d %I:%M:%S %p', Date_Complaint_Received) as complaint_received_at,
-        safe.parse_timestamp('%Y %b %d %I:%M:%S %p', DOBRunDate) as dob_run_date
+        safe.parse_timestamp('%m/%d/%Y %I:%M:%S %p', Date_Complaint_Received) as complaint_received_at,
+        safe.parse_timestamp('%m/%d/%Y %I:%M:%S %p', DOBRunDate) as dob_run_date
     from {{ source('raw_dob', 'stalled_construction') }}
     where BIN is not null
 )

--- a/dbt/models/staging/stg_vacancy.sql
+++ b/dbt/models/staging/stg_vacancy.sql
@@ -3,7 +3,7 @@
 */
 
 select bbl,
-cast(bbl as string) as bbl_key,
+{{ bbl_key_from_parts('borocode', 'block', 'lot') }} as bbl_key,
 range(
   date( concat('20', substring(version, 0, 2), '-1-1') ),
   date_add(date( concat('20', substring(version, 0, 2), '-1-1')), interval 1 year)


### PR DESCRIPTION
While kicking around the lineage [visualization in dbt docs](https://empty.nyc/dbt-docs/#!/overview?g_v=1), I noticed that `mart_vacant_lots` does not actually inherit from `stg_vacancy` or `stg_vacant_range`.

<img width="2264" height="1223" alt="Screenshot 2026-06-10 at 3 54 09 PM (2)" src="https://github.com/user-attachments/assets/7eadc09e-db80-4388-9d9f-bf4c166f2e2a" />

I had forgotten that a bunch of SQL used for the map tiles is hiding out in the `build/` directory and called from a shell script.

This PR moves those transformations into dbt and includes some minor dbt cleanup as well.

The resulting lineage for `mart_vacant_lots` now includes those staging steps (and the new intermediate step)

<img width="2334" height="1140" alt="Screenshot 2026-06-17 at 1 51 51 PM" src="https://github.com/user-attachments/assets/35b3d427-af70-4bf9-bdcc-6fa8211a577f" />


