### PR TITLE
Add planimetric parking lots to raw data bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ raw_pluto_dataset = raw_pluto
 raw_dob_dataset = raw_dob
 
 .PHONY: clean watch tiles.cors build tiles_from_bq \
-	vendor.permits vendor.stalled vendor.building vendor.pluto vendor.pluto.upload \
+	vendor.permits vendor.stalled vendor.building vendor.parking vendor.pluto vendor.pluto.upload \
 	vendor.geometry vendor.geometry.upload \
 	bq.load.permits bq.load.stalled bq.load.building \
 	bq.load.pluto bq.load.geometry dbt.build
@@ -75,6 +75,11 @@ vendor.stalled:
 
 vendor.building:
 	RAW_BUCKET=$(raw_bucket) ./build/vendor_dataset.sh --slug dob_building
+
+# Planimetric parking lots (OTI) — single CSV with WKT geometry, snapshotted to
+# $(raw_bucket)/planimetric/planimetric_parking.csv.
+vendor.parking:
+	RAW_BUCKET=$(raw_bucket) ./build/vendor_dataset.sh --slug planimetric_parking
 
 vendor.pluto:
 	./build/get_historical_pluto.sh

--- a/build/sources.tsv
+++ b/build/sources.tsv
@@ -29,3 +29,6 @@ mappluto	mappluto_26v1	https://s-media.nyc.gov/agencies/dcp/assets/files/zip/dat
 dob	dob_permit_issuance	https://data.cityofnewyork.us/api/views/ipu4-2q9a/rows.csv?accessType=DOWNLOAD	permit_issuance.csv	NYC Department of Buildings	ipu4-2q9a
 dob	dob_stalled_construction	https://data.cityofnewyork.us/api/views/i296-73x5/rows.csv?accessType=DOWNLOAD	stalled_construction.csv	NYC Department of Buildings	i296-73x5
 dob	dob_building	https://data.cityofnewyork.us/api/views/5zhs-2jue/rows.csv?accessType=DOWNLOAD	building.csv	NYC DOITT	5zhs-2jue
+# Planimetric datasets (data.cityofnewyork.us) — single CSV with WKT geometry,
+# fetched + snapshotted to GCS by build/vendor_dataset.sh (make vendor.parking).
+planimetric	planimetric_parking	https://data.cityofnewyork.us/api/v3/views/7cgt-uhhz/export.csv?accessType=DOWNLOAD	planimetric_parking.csv	NYC Office of Technology & Innovation	7cgt-uhhz


### PR DESCRIPTION
On a call with @ecalifornica and @holistudio, we thought it would be cool to add data about parking lots from the NYC ["Planimetric Database"](https://data.cityofnewyork.us/City-Government/NYC-Planimetric-Database-Parking-Lot/7cgt-uhhz/about_data).

empty.nyc currently maps out lots that are *entirely* devoted to surface parking, but the planimetric dataset seems to have more granular information about the size and shape of parking structures.

This PR just adds the specific CSV from the open data portal to our list of sources, adds a make target to download the CSV and upload it to a google cloud bucket. It does not load the data into bigquery yet (that's the next step)

The contents of the google cloud bucket now include the CSV!:

<img width="3104" height="1974" alt="Screenshot 2026-06-19 at 2 03 47 PM" src="https://github.com/user-attachments/assets/58980602-e65b-492d-ba20-01c28dd57f5a" />


