### PR TITLE
Load new planimetric parking data into raw bigquery dataset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,12 @@ raw_bucket = gs://nyc-lots-raw-data
 # BigQuery datasets the raw data loads into (project is $(gcproject) above).
 raw_pluto_dataset = raw_pluto
 raw_dob_dataset = raw_dob
+raw_planimetric_dataset = raw_planimetric
 
 .PHONY: clean watch tiles.cors build tiles_from_bq \
 	vendor.permits vendor.stalled vendor.building vendor.parking vendor.pluto vendor.pluto.upload \
 	vendor.geometry vendor.geometry.upload \
-	bq.load.permits bq.load.stalled bq.load.building \
+	bq.load.permits bq.load.stalled bq.load.building bq.load.parking \
 	bq.load.pluto bq.load.geometry dbt.build
 
 clean:
@@ -66,6 +67,7 @@ tiles.vacant_bq:
 PERMITS_CSV  = $(raw_bucket)/dob/permit_issuance.csv
 STALLED_CSV  = $(raw_bucket)/dob/stalled_construction.csv
 BUILDING_CSV = $(raw_bucket)/dob/building.csv
+PARKING_CSV  = $(raw_bucket)/planimetric/planimetric_parking.csv
 
 vendor.permits:
 	RAW_BUCKET=$(raw_bucket) ./build/vendor_dataset.sh --slug dob_permit_issuance
@@ -117,6 +119,14 @@ bq.load.building:
 		$(gcproject):$(raw_dob_dataset).building \
 		$(BUILDING_CSV) \
 		build/schemas/building.json
+
+# Planimetric parking lots (OTI) -> raw_planimetric.planimetric_parking.
+# Run `make vendor.parking` first to snapshot the CSV into the raw bucket.
+bq.load.parking:
+	bq load --source_format=CSV --skip_leading_rows=1 --allow_quoted_newlines --replace \
+		$(gcproject):$(raw_planimetric_dataset).planimetric_parking \
+		$(PARKING_CSV) \
+		build/schemas/planimetric_parking.json
 
 # PLUTO: one all-STRING table per yearly release in raw_pluto (dataset is
 # created in terraform/bigquery.tf). Combining the releases is a dbt concern.

--- a/build/schemas/planimetric_parking.json
+++ b/build/schemas/planimetric_parking.json
@@ -1,0 +1,9 @@
+[
+  {"name": "the_geom", "type": "STRING"},
+  {"name": "SOURCE_ID", "type": "STRING"},
+  {"name": "FEAT_CODE", "type": "STRING"},
+  {"name": "SUB_CODE", "type": "STRING"},
+  {"name": "STATUS", "type": "STRING"},
+  {"name": "SHAPE_Leng", "type": "STRING"},
+  {"name": "SHAPE_Area", "type": "STRING"}
+]

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -44,6 +44,22 @@ sources:
             dataset_id: "5zhs-2jue"
             download_url: "https://data.cityofnewyork.us/api/views/5zhs-2jue/rows.csv?accessType=DOWNLOAD"
 
+  - name: raw_planimetric
+    database: empty-lots
+    schema: raw_planimetric
+    description: "NYC planimetric open data (OTI), vendored as CSV snapshots with WKT geometry."
+    tables:
+      - name: planimetric_parking
+        description: >
+          Parking lot polygons (the_geom as WKT MULTIPOLYGON, all columns STRING).
+          Loaded via make vendor.parking && make bq.load.parking.
+        config:
+          meta:
+            publisher: "NYC Office of Technology & Innovation"
+            source_url: "https://data.cityofnewyork.us/d/7cgt-uhhz"
+            dataset_id: "7cgt-uhhz"
+            download_url: "https://data.cityofnewyork.us/api/v3/views/7cgt-uhhz/export.csv?accessType=DOWNLOAD"
+
   - name: raw_pluto
     database: empty-lots
     schema: raw_pluto

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -27,3 +27,14 @@ resource "google_bigquery_dataset" "raw_dob" {
 
   depends_on = [google_project_service.bigquery]
 }
+
+# Raw vendored NYC planimetric open data (OTI) — single-CSV snapshots with WKT
+# geometry (e.g. parking lots), loaded from gs://nyc-lots-raw-data — not dbt-built.
+resource "google_bigquery_dataset" "raw_planimetric" {
+  dataset_id  = "raw_planimetric"
+  project     = google_project.empty_lots.project_id
+  location    = "us-east4"
+  description = "Raw vendored NYC planimetric open data (OTI; loaded from CSV snapshots, not dbt-built)."
+
+  depends_on = [google_project_service.bigquery]
+}


### PR DESCRIPTION
This builds off of #113

It loads data from the CSV at `gs://nyc-lots-raw-data/planimetric/planimetric_parking.csv` into a raw dataset in bigquery (no real schema, treats everything as strings)

Includes relevant Terraform update to create the new dataset.

Here's the updated dbt lineage:

<img width="2354" height="1106" alt="dbt-dag(3)" src="https://github.com/user-attachments/assets/1e384c53-30d0-44c3-94cb-45d35d246b0d" />
