### PR TITLE
Add planimetric parking staging model

### DIFF
--- a/dbt/models/staging/schema.yml
+++ b/dbt/models/staging/schema.yml
@@ -334,3 +334,35 @@ models:
         description: "Building Identification Number"
         tests:
           - not_null
+
+  - name: stg_planimetric_parking
+    description: >
+      Staged NYC planimetric parking lots (OTI basemap): comma-separated numeric
+      codes/measurements cleaned to numbers and the_geom WKT parsed to GEOGRAPHY.
+      Distinct from stg_parking, which is PLUTO landuse-derived.
+    columns:
+      - name: source_id
+        description: "Unique feature identification number; 0 for features new in the 2022 collection."
+        data_type: int64
+      - name: feat_code
+        description: "Feature code indicating the type of feature in the planimetric basemap."
+        data_type: int64
+      - name: sub_code
+        description: "Sub-feature code: a subset of features within a given feat_code."
+        data_type: int64
+      - name: status
+        description: "Feature status in the 2022 planimetrics update: New, Updated, or Unchanged."
+        data_type: string
+        tests:
+          - not_null
+      - name: shape_length
+        description: "Polygon perimeter in US feet (source projection NAD83 / NY Long Island ftUS)."
+        data_type: float64
+      - name: shape_area
+        description: "Polygon area in square US feet (source projection NAD83 / NY Long Island ftUS)."
+        data_type: float64
+      - name: geometry
+        description: "Parking lot polygon (GEOGRAPHY, WGS-84), parsed from the_geom WKT; make_valid repairs 13 invalid rows."
+        data_type: geography
+        tests:
+          - not_null

--- a/dbt/models/staging/stg_planimetric_parking.sql
+++ b/dbt/models/staging/stg_planimetric_parking.sql
@@ -1,0 +1,24 @@
+/*
+    Staging model for NYC planimetric parking lots (OTI basemap).
+
+    The raw table loads all-STRING; the numeric columns carry comma
+    thousands-separators (e.g. "5,000", "4,566.43"), so strip commas before
+    casting. the_geom is WKT in WGS-84 — 13 of 20,429 rows are
+    invalid-but-parseable and are repaired by make_valid.
+
+    Note: shape_length / shape_area come from the source projection
+    (NAD83 / NY Long Island ftUS), so they are in feet and square feet — not
+    the meters that ST_* geography functions return.
+
+    Distinct from stg_parking, which is PLUTO landuse-derived (not basemap).
+*/
+
+select
+    safe_cast(replace(SOURCE_ID, ',', '') as int64) as source_id,
+    safe_cast(replace(FEAT_CODE, ',', '') as int64) as feat_code,
+    safe_cast(replace(SUB_CODE, ',', '') as int64) as sub_code,
+    STATUS as status,
+    safe_cast(replace(SHAPE_Leng, ',', '') as float64) as shape_length,
+    safe_cast(replace(SHAPE_Area, ',', '') as float64) as shape_area,
+    st_geogfromtext(the_geom, make_valid => true) as geometry,
+from {{ source('raw_planimetric', 'planimetric_parking') }}


### PR DESCRIPTION
Builds off of #114 

This creates a more usable "staging" model, casting the raw strings to appropriate types.

Resulting lineage:

<img width="2354" height="1106" alt="dbt-dag(4)" src="https://github.com/user-attachments/assets/cc57a09e-24e2-443e-89a6-3a7d2c23cded" />
