### PR TITLE
Update parking lot query

### DIFF
--- a/dbt/models/staging/stg_parking.sql
+++ b/dbt/models/staging/stg_parking.sql
@@ -1,5 +1,4 @@
 select *
 from {{ ref('stg_lots') }}
 where landuse = '10'
-and bldgclass in ('G0', 'G1', 'G6', 'G7')
-and numbldgs = 0
+and bldgarea = 0


### PR DESCRIPTION
@ecalifornica noticed some parking lots missing from the empty.nyc map.

Looking closer, many parking lots were listed as having 1 building on them, while the "building area" was  0.

This update looks at that building area value instead of number of buildings.