### PR TITLE
Add 2026 PLUTO data

### DIFF
--- a/build/schemas/pluto_26v1.json
+++ b/build/schemas/pluto_26v1.json
@@ -1,0 +1,398 @@
+[
+  {
+    "name": "borough",
+    "type": "STRING"
+  },
+  {
+    "name": "block",
+    "type": "STRING"
+  },
+  {
+    "name": "lot",
+    "type": "STRING"
+  },
+  {
+    "name": "cd",
+    "type": "STRING"
+  },
+  {
+    "name": "bct2020",
+    "type": "STRING"
+  },
+  {
+    "name": "bctcb2020",
+    "type": "STRING"
+  },
+  {
+    "name": "ct2010",
+    "type": "STRING"
+  },
+  {
+    "name": "cb2010",
+    "type": "STRING"
+  },
+  {
+    "name": "schooldist",
+    "type": "STRING"
+  },
+  {
+    "name": "council",
+    "type": "STRING"
+  },
+  {
+    "name": "zipcode",
+    "type": "STRING"
+  },
+  {
+    "name": "firecomp",
+    "type": "STRING"
+  },
+  {
+    "name": "policeprct",
+    "type": "STRING"
+  },
+  {
+    "name": "healthcenterdistrict",
+    "type": "STRING"
+  },
+  {
+    "name": "healtharea",
+    "type": "STRING"
+  },
+  {
+    "name": "sanitboro",
+    "type": "STRING"
+  },
+  {
+    "name": "sanitdistrict",
+    "type": "STRING"
+  },
+  {
+    "name": "sanitsub",
+    "type": "STRING"
+  },
+  {
+    "name": "address",
+    "type": "STRING"
+  },
+  {
+    "name": "zonedist1",
+    "type": "STRING"
+  },
+  {
+    "name": "zonedist2",
+    "type": "STRING"
+  },
+  {
+    "name": "zonedist3",
+    "type": "STRING"
+  },
+  {
+    "name": "zonedist4",
+    "type": "STRING"
+  },
+  {
+    "name": "overlay1",
+    "type": "STRING"
+  },
+  {
+    "name": "overlay2",
+    "type": "STRING"
+  },
+  {
+    "name": "spdist1",
+    "type": "STRING"
+  },
+  {
+    "name": "spdist2",
+    "type": "STRING"
+  },
+  {
+    "name": "spdist3",
+    "type": "STRING"
+  },
+  {
+    "name": "ltdheight",
+    "type": "STRING"
+  },
+  {
+    "name": "splitzone",
+    "type": "STRING"
+  },
+  {
+    "name": "bldgclass",
+    "type": "STRING"
+  },
+  {
+    "name": "landuse",
+    "type": "STRING"
+  },
+  {
+    "name": "easements",
+    "type": "STRING"
+  },
+  {
+    "name": "ownertype",
+    "type": "STRING"
+  },
+  {
+    "name": "ownername",
+    "type": "STRING"
+  },
+  {
+    "name": "lotarea",
+    "type": "STRING"
+  },
+  {
+    "name": "bldgarea",
+    "type": "STRING"
+  },
+  {
+    "name": "comarea",
+    "type": "STRING"
+  },
+  {
+    "name": "resarea",
+    "type": "STRING"
+  },
+  {
+    "name": "officearea",
+    "type": "STRING"
+  },
+  {
+    "name": "retailarea",
+    "type": "STRING"
+  },
+  {
+    "name": "garagearea",
+    "type": "STRING"
+  },
+  {
+    "name": "strgearea",
+    "type": "STRING"
+  },
+  {
+    "name": "factryarea",
+    "type": "STRING"
+  },
+  {
+    "name": "otherarea",
+    "type": "STRING"
+  },
+  {
+    "name": "areasource",
+    "type": "STRING"
+  },
+  {
+    "name": "numbldgs",
+    "type": "STRING"
+  },
+  {
+    "name": "numfloors",
+    "type": "STRING"
+  },
+  {
+    "name": "unitsres",
+    "type": "STRING"
+  },
+  {
+    "name": "unitstotal",
+    "type": "STRING"
+  },
+  {
+    "name": "lotfront",
+    "type": "STRING"
+  },
+  {
+    "name": "lotdepth",
+    "type": "STRING"
+  },
+  {
+    "name": "bldgfront",
+    "type": "STRING"
+  },
+  {
+    "name": "bldgdepth",
+    "type": "STRING"
+  },
+  {
+    "name": "ext",
+    "type": "STRING"
+  },
+  {
+    "name": "proxcode",
+    "type": "STRING"
+  },
+  {
+    "name": "irrlotcode",
+    "type": "STRING"
+  },
+  {
+    "name": "lottype",
+    "type": "STRING"
+  },
+  {
+    "name": "bsmtcode",
+    "type": "STRING"
+  },
+  {
+    "name": "assessland",
+    "type": "STRING"
+  },
+  {
+    "name": "assesstot",
+    "type": "STRING"
+  },
+  {
+    "name": "exempttot",
+    "type": "STRING"
+  },
+  {
+    "name": "yearbuilt",
+    "type": "STRING"
+  },
+  {
+    "name": "yearalter1",
+    "type": "STRING"
+  },
+  {
+    "name": "yearalter2",
+    "type": "STRING"
+  },
+  {
+    "name": "histdist",
+    "type": "STRING"
+  },
+  {
+    "name": "landmark",
+    "type": "STRING"
+  },
+  {
+    "name": "builtfar",
+    "type": "STRING"
+  },
+  {
+    "name": "residfar",
+    "type": "STRING"
+  },
+  {
+    "name": "commfar",
+    "type": "STRING"
+  },
+  {
+    "name": "facilfar",
+    "type": "STRING"
+  },
+  {
+    "name": "borocode",
+    "type": "STRING"
+  },
+  {
+    "name": "bbl",
+    "type": "STRING"
+  },
+  {
+    "name": "condono",
+    "type": "STRING"
+  },
+  {
+    "name": "tract2010",
+    "type": "STRING"
+  },
+  {
+    "name": "xcoord",
+    "type": "STRING"
+  },
+  {
+    "name": "ycoord",
+    "type": "STRING"
+  },
+  {
+    "name": "zonemap",
+    "type": "STRING"
+  },
+  {
+    "name": "zmcode",
+    "type": "STRING"
+  },
+  {
+    "name": "sanborn",
+    "type": "STRING"
+  },
+  {
+    "name": "taxmap",
+    "type": "STRING"
+  },
+  {
+    "name": "edesignum",
+    "type": "STRING"
+  },
+  {
+    "name": "appbbl",
+    "type": "STRING"
+  },
+  {
+    "name": "appdate",
+    "type": "STRING"
+  },
+  {
+    "name": "plutomapid",
+    "type": "STRING"
+  },
+  {
+    "name": "firm07_flag",
+    "type": "STRING"
+  },
+  {
+    "name": "pfirm15_flag",
+    "type": "STRING"
+  },
+  {
+    "name": "version",
+    "type": "STRING"
+  },
+  {
+    "name": "dcpedited",
+    "type": "STRING"
+  },
+  {
+    "name": "latitude",
+    "type": "STRING"
+  },
+  {
+    "name": "longitude",
+    "type": "STRING"
+  },
+  {
+    "name": "notes",
+    "type": "STRING"
+  },
+  {
+    "name": "mih_opt1",
+    "type": "STRING"
+  },
+  {
+    "name": "mih_opt2",
+    "type": "STRING"
+  },
+  {
+    "name": "mih_opt3",
+    "type": "STRING"
+  },
+  {
+    "name": "mih_opt4",
+    "type": "STRING"
+  },
+  {
+    "name": "trnstzone",
+    "type": "STRING"
+  },
+  {
+    "name": "affresfar",
+    "type": "STRING"
+  },
+  {
+    "name": "mnffar",
+    "type": "STRING"
+  }
+]

--- a/build/sources.tsv
+++ b/build/sources.tsv
@@ -13,6 +13,7 @@
 # PLUTO releases (DCP BYTES of the BIG APPLE) — zip of CSV, fetched by
 # build/get_historical_pluto.sh  (make vendor.pluto).
 type	slug	url	filename	publisher	dataset_id
+pluto	pluto_26v1	https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pluto/nyc_pluto_26v1_csv.zip	pluto_26v1.zip	NYC Department of City Planning	26v1
 pluto	pluto_25v3	https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pluto/nyc_pluto_25v3_arc_csv.zip	pluto_25v3.zip	NYC Department of City Planning	25v3
 pluto	pluto_24v4_1	https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pluto/nyc_pluto_24v4_1_arc_csv.zip	pluto_24v4_1.zip	NYC Department of City Planning	24v4_1
 pluto	pluto_23v3_1	https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pluto/nyc_pluto_23v3_1_arc_csv.zip	pluto_23v3_1.zip	NYC Department of City Planning	23v3_1

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -94,3 +94,5 @@ sources:
         description: "PLUTO release 24v4_1 (all columns STRING). Loaded via make bq.load.pluto."
       - name: pluto_25v3
         description: "PLUTO release 25v3 (all columns STRING). Loaded via make bq.load.pluto."
+      - name: pluto_26v1
+        description: "PLUTO release 25v3 (all columns STRING). Loaded via make bq.load.pluto."

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -95,4 +95,4 @@ sources:
       - name: pluto_25v3
         description: "PLUTO release 25v3 (all columns STRING). Loaded via make bq.load.pluto."
       - name: pluto_26v1
-        description: "PLUTO release 25v3 (all columns STRING). Loaded via make bq.load.pluto."
+        description: "PLUTO release 26v1 (all columns STRING). Loaded via make bq.load.pluto."

--- a/dbt/models/staging/stg_lots.sql
+++ b/dbt/models/staging/stg_lots.sql
@@ -9,6 +9,8 @@ with combined as (
             source('raw_pluto', 'pluto_23v3_1'),
             source('raw_pluto', 'pluto_24v4_1'),
             source('raw_pluto', 'pluto_25v3'),
+            source('raw_pluto', 'pluto_26v1'),
+
         ],
         source_column_name=none
     ) }}


### PR DESCRIPTION
New PLUTO data is available from [NYC Planning](https://www.nyc.gov/content/planning/pages/resources/datasets/mappluto-pluto-change#recent-release) for 2026.

This will give us more recent vacancy data and let us see lots vacant for up to 9 years.

A fair amount of manual work was involved that should be automated in the future. I'm noting my steps here for reference.

1. Added the new URL in `sources.tsv`
2. Ran `make vendor.pluto` to pull down all of the historical files into a local `./historical` directory
3. Ran `make vendor.pluto.upload` to upload the relevant CSVs to a google cloud bucket.
4. Generated string-only schema for the new dataset with `./build/gen_string_schema.sh historical/pluto_26v1/pluto_26v1.csv > build/schemas/pluto_26v1.json` (and committed the new file to the repository)
5. Ran `make bq.load.pluto` to slurp up the 2026 data into the `raw_pluto` dataset.
6. Updated `sources.yml` to let dbt know about the new raw_pluto table, and `stg_lots.sql` to add the 2026 data to the pipeline.

