### PR TITLE
Update "lots" query (remove address check)

### DIFF
--- a/dbt/models/staging/stg_lots.sql
+++ b/dbt/models/staging/stg_lots.sql
@@ -135,4 +135,3 @@ select
     version
 
 from combined
-where address is not null


### PR DESCRIPTION
This is basically a no-op, but we don't care about whether the address is `null` or not.