### PR TITLE
Handle google streetview errors in UI

### DIFF
--- a/src/streetview.ts
+++ b/src/streetview.ts
@@ -46,9 +46,10 @@ export function showStreetViewPanorama([lng, lat]: [number, number])  {
     panorama.setVisible(true)
   })
   .catch(
-    () => {
+    (err: unknown) => {
       // If we don't have a streetview image, hide the streetview element (and previous results)
       panorama.setVisible(false)
+      console.error("streetview error", err)
     }
   )
 }

--- a/src/streetview.ts
+++ b/src/streetview.ts
@@ -28,7 +28,14 @@ export function showStreetViewPanorama([lng, lat]: [number, number])  {
     location: {lng: parseFloat(lng), lat: parseFloat(lat)},
     sources: [google.maps.StreetViewSource.OUTDOOR],
     radius: 50,
-  }, (panoData: google.maps.StreetViewPanoramaData | null) => {
+  }, (panoData: google.maps.StreetViewPanoramaData | null, status: google.maps.StreetViewStatus | null) => {
+
+    // If we don't have a streetview image, hide the streetview element (and previous results)
+    if (status !== google.maps.StreetViewStatus.OK) {
+      panorama.setVisible(false)
+      return
+    }
+
 
     const lat1 = panoData?.location?.latLng?.lat() || 0
     const lng1 = panoData?.location?.latLng?.lng() || 0
@@ -40,5 +47,7 @@ export function showStreetViewPanorama([lng, lat]: [number, number])  {
 
     panoData?.location?.pano && panorama.setPano(panoData.location.pano)
     panorama.setPov({heading, pitch: 0})
+    panorama.setOptions({imageDateControl: true})
+    panorama.setVisible(true)
   })
 }

--- a/src/streetview.ts
+++ b/src/streetview.ts
@@ -28,14 +28,9 @@ export function showStreetViewPanorama([lng, lat]: [number, number])  {
     location: {lng: parseFloat(lng), lat: parseFloat(lat)},
     sources: [google.maps.StreetViewSource.OUTDOOR],
     radius: 50,
-  }, (panoData: google.maps.StreetViewPanoramaData | null, status: google.maps.StreetViewStatus | null) => {
-
-    // If we don't have a streetview image, hide the streetview element (and previous results)
-    if (status !== google.maps.StreetViewStatus.OK) {
-      panorama.setVisible(false)
-      return
-    }
-
+  })
+  .then(
+    ({data: panoData}: google.maps.StreetViewResponse) => {
 
     const lat1 = panoData?.location?.latLng?.lat() || 0
     const lng1 = panoData?.location?.latLng?.lng() || 0
@@ -50,4 +45,10 @@ export function showStreetViewPanorama([lng, lat]: [number, number])  {
     panorama.setOptions({imageDateControl: true})
     panorama.setVisible(true)
   })
+  .catch(
+    () => {
+      // If we don't have a streetview image, hide the streetview element (and previous results)
+      panorama.setVisible(false)
+    }
+  )
 }


### PR DESCRIPTION
Currently, if google doesn't have a streetview image for a lat/lon, we don't do anything. It can be confusing if you're looking at information about a particular property but a previous selection is displayed.