### PR TITLE
Detail window should appear when user loads a URL with lat and lng params

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { initStreetview, showStreetViewPanorama  } from "./streetview";
-import { initMap } from "./map";
+import { initMap, createInfoWindow } from "./map";
 import type { Map, MapLayerMouseEvent} from "maplibre-gl";
 
 function markerClickHandler(e: MapLayerMouseEvent) {
@@ -8,13 +8,26 @@ function markerClickHandler(e: MapLayerMouseEvent) {
 }
 
 async function init(): Promise<void> {
-  const libremap = initMap()
+  const params = new URLSearchParams(window.location.search)
+  const lat = Number(params.get("lat"))
+  const lng = Number(params.get("lng"))
+
+  const libremap = initMap(lat,lng)
+
   libremap.then((m: Map)=>{
-    m.on('load', () => {
-        const params = new URLSearchParams(window.location.search)
-        if ( params.size >= 2) {
-          showStreetViewPanorama([params.get("lng"), params.get("lat")])
-        }
+    m.once('idle', () => {
+      if (!lat || !lng) return
+      showStreetViewPanorama([lng, lat])
+
+      let point = m.project([lng, lat])
+      let features = m.queryRenderedFeatures(point)
+
+      if (!features || features.length === 0) return;
+      const properties = features[0].properties;
+
+      createInfoWindow(properties)
+        .setLngLat([lng, lat])
+        .addTo(m)
     })
     m.on('click', ['parkinglots', 'lotpolygons'], markerClickHandler);
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ async function init(): Promise<void> {
   const libremap = initMap(lat,lng)
 
   libremap.then((m: Map)=>{
+    m.on('load', () => {
+      if (!lat || !lng) return
+      showStreetViewPanorama([lng, lat])
+    })
     m.once('idle', () => {
       if (!lat || !lng) return
       showStreetViewPanorama([lng, lat])

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,11 @@ function markerClickHandler(e: MapLayerMouseEvent) {
 
 async function init(): Promise<void> {
   const params = new URLSearchParams(window.location.search)
-  const lat = Number(params.get("lat"))
-  const lng = Number(params.get("lng"))
+  const lat = Number(params.get("lat")) || undefined
+  const lng = Number(params.get("lng")) || undefined
+  const zoom = lat && lng && 16
 
-  const libremap = initMap(lat,lng)
+  const libremap = initMap(lat, lng, zoom)
 
   libremap.then((m: Map)=>{
     m.on('load', () => {

--- a/src/infoWindow.ts
+++ b/src/infoWindow.ts
@@ -3,7 +3,6 @@ class InfoWindow extends HTMLElement {
 
   constructor() {
     super();
-    //this.render();
   }
 
   set data(value: any) {

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,20 +1,42 @@
-import maplibregl, { Map, MapLayerMouseEvent } from 'maplibre-gl';
+import maplibregl, { Map, MapLayerMouseEvent, Popup } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { Protocol } from "pmtiles";
 
 import "./infoWindow"
 
-export async function initMap(): Promise<Map>{
+const center_default = [-73.979736, 40.7565749]
+const zoom_default = 13
+
+export function createInfoWindow(props): Popup {
+  const lotinfowindow = document.createElement("info-window") as any
+
+  lotinfowindow.data = {
+    bbl: props.bbl,
+    address: props.address,
+    ownername: props.ownername,
+    lotArea: Number(props.lotarea).toLocaleString(),
+    zolaLink: `https://zola.planning.nyc.gov/l/lot/${props.borocode}/${props.block}/${props.lot}`,
+    numPermits: Number(props.num_permits) || 0,
+    latestPermitDate: props.latest_permit_date,
+    numStalledComplaints: Number(props.num_stalled_complaints) || 0,
+    vacantSince: props.vacant_since ? new Date(`${props.vacant_since}T00:00:00`) : null
+  }
+
+  return new maplibregl.Popup({ offset: { bottom: [0, -5] } })
+    .setDOMContent(lotinfowindow)
+}
+
+
+export async function initMap(loadlat=null,loadlng=null): Promise<Map>{
   let protocol = new Protocol();
   maplibregl.addProtocol("pmtiles",protocol.tile);
 
-  var center = [-73.979736, 40.7565749]
-  var zoom = 13
+  var center = center_default
+  var zoom = zoom_default
 
-  const params = new URLSearchParams(window.location.search)
-  if ( params.size >= 2) {
-    center = [params.get("lng"), params.get("lat")]
-    console.log(`setting center to ${center}`)
+  if (loadlat && loadlng) {
+    center = [loadlng,loadlat]
+    console.debug(`setting center to ${center}`)
     zoom = 16
   }
 
@@ -26,7 +48,6 @@ export async function initMap(): Promise<Map>{
   })
 
   map.on('load', async () => {
-
     // Add geolocate control to the map.
     map.addControl(
       new maplibregl.GeolocateControl({
@@ -102,33 +123,23 @@ export async function initMap(): Promise<Map>{
     map.on('click', ['lotpolygons', 'parkinglots'], (e: MapSourceMapEvent) => {
       const { lng, lat } = e.lngLat
       if (!e.features || e.features.length === 0) return;
-      const props = e.features[0].properties;
-
+      const properties = e.features[0].properties;
 
       map.removeFeatureState({ source: 'vacant', sourceLayer:'lots' });
       map.setFeatureState(
         {
           source: 'vacant',
           sourceLayer: 'lots',
-          id: props.bbl,
+          id: properties.bbl,
         },
         {
           selected: true,
         }
       );
 
-      const lotinfowindow = document.createElement("info-window") as any
-      lotinfowindow.data = {
-        bbl: props.bbl,
-        address: props.address,
-        ownername: props.ownername,
-        lotArea: Number(props.lotarea).toLocaleString(),
-        zolaLink: `https://zola.planning.nyc.gov/l/lot/${props.borocode}/${props.block}/${props.lot}`,
-        numPermits: Number(props.num_permits) || 0,
-        latestPermitDate: props.latest_permit_date,
-        numStalledComplaints: Number(props.num_stalled_complaints) || 0,
-        vacantSince: props.vacant_since ? new Date(`${props.vacant_since}T00:00:00`) : null
-      }
+      createInfoWindow(properties)
+        .setLngLat([lng, lat])
+        .addTo(map);
 
       map.easeTo({center: [lng, lat]})
 
@@ -136,11 +147,6 @@ export async function initMap(): Promise<Map>{
       url.searchParams.set("lat", lat);
       url.searchParams.set("lng", lng);
       history.pushState({}, "", url)
-
-      new maplibregl.Popup({ offset: { 'bottom': [0, -5] } })
-        .setLngLat([lng, lat])
-        .setDOMContent(lotinfowindow)
-        .addTo(map);
     })
   })
   return map

--- a/src/map.ts
+++ b/src/map.ts
@@ -116,7 +116,7 @@ export async function initMap(init_lat=lat_default,init_lng=lng_default, zoom=zo
 
       map.easeTo({center: [lng, lat]})
 
-      const url = new URL(window.location);
+      const url = new URL(window.location.href);
       url.searchParams.set("lat", String(lat));
       url.searchParams.set("lng", String(lng));
       history.pushState({}, "", url)

--- a/src/map.ts
+++ b/src/map.ts
@@ -86,34 +86,12 @@ export async function initMap(init_lat=lat_default,init_lng=lng_default, zoom=zo
       }
     });
 
-
-    var hovered: [] = []
-
     map.on('mousemove', ['lotpolygons', 'parkinglots'], (e: MapLayerMouseEvent) => {
       map.getCanvas().style.cursor = "pointer";
-      if (e.features && e.features.length > 0) {
-        map.setFeatureState({
-          source: 'vacant',
-          sourceLayer: 'lots',
-          id: e.features[0].properties.bbl,
-        }, {
-          hover: true
-        });
-        e.features[0].id && hovered.push(e.features[0].properties.bbl)
-      }
     });
 
     map.on('mouseleave',['parkinglots', 'lotpolygons'], (e: MapLayerMouseEvent) => {
       map.getCanvas().style.cursor = "default";
-      while (hovered.length > 0) {
-        map.setFeatureState({
-          source: 'vacant',
-          sourceLayer: 'vacant',
-          id: hovered.pop(),
-        }, {
-          hover: false
-        });
-      }
     });
 
     map.on('click', ['lotpolygons', 'parkinglots'], (e: MapLayerMouseEvent) => {

--- a/src/map.ts
+++ b/src/map.ts
@@ -4,7 +4,8 @@ import { Protocol } from "pmtiles";
 
 import "./infoWindow"
 
-const center_default = [-73.979736, 40.7565749]
+const lng_default = -73.979736
+const lat_default = 40.7565749
 const zoom_default = 13
 
 // TODO: define type for props passed in.
@@ -27,18 +28,13 @@ export function createInfoWindow(props: any): Popup {
     .setDOMContent(lotinfowindow)
 }
 
-export async function initMap(loadlat=null,loadlng=null): Promise<Map>{
+export async function initMap(init_lat=lat_default,init_lng=lng_default, zoom=zoom_default): Promise<Map>{
   let protocol = new Protocol();
   maplibregl.addProtocol("pmtiles",protocol.tile);
 
-  var center = center_default
-  var zoom = zoom_default
+  const center = [init_lng, init_lat]
 
-  if (loadlat && loadlng) {
-    center = [loadlng,loadlat]
-    console.debug(`setting center to ${center}`)
-    zoom = 16
-  }
+  console.debug(`setting center to ${center}`)
 
   const map = new maplibregl.Map({
     container: 'map', // container id

--- a/src/map.ts
+++ b/src/map.ts
@@ -32,8 +32,7 @@ export async function initMap(init_lat=lat_default,init_lng=lng_default, zoom=zo
   let protocol = new Protocol();
   maplibregl.addProtocol("pmtiles",protocol.tile);
 
-  const center = [init_lng, init_lat]
-
+  const center: [number, number] = [init_lng, init_lat]
   console.debug(`setting center to ${center}`)
 
   const map = new maplibregl.Map({

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,4 +1,4 @@
-import maplibregl, { Map, MapLayerMouseEvent, Popup } from 'maplibre-gl';
+import maplibregl, { Map, Popup, MapLayerMouseEvent } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { Protocol } from "pmtiles";
 
@@ -7,7 +7,8 @@ import "./infoWindow"
 const center_default = [-73.979736, 40.7565749]
 const zoom_default = 13
 
-export function createInfoWindow(props): Popup {
+// TODO: define type for props passed in.
+export function createInfoWindow(props: any): Popup {
   const lotinfowindow = document.createElement("info-window") as any
 
   lotinfowindow.data = {
@@ -25,7 +26,6 @@ export function createInfoWindow(props): Popup {
   return new maplibregl.Popup({ offset: { bottom: [0, -5] } })
     .setDOMContent(lotinfowindow)
 }
-
 
 export async function initMap(loadlat=null,loadlng=null): Promise<Map>{
   let protocol = new Protocol();
@@ -120,7 +120,7 @@ export async function initMap(loadlat=null,loadlng=null): Promise<Map>{
       }
     });
 
-    map.on('click', ['lotpolygons', 'parkinglots'], (e: MapSourceMapEvent) => {
+    map.on('click', ['lotpolygons', 'parkinglots'], (e: MapLayerMouseEvent) => {
       const { lng, lat } = e.lngLat
       if (!e.features || e.features.length === 0) return;
       const properties = e.features[0].properties;

--- a/src/map.ts
+++ b/src/map.ts
@@ -140,8 +140,8 @@ export async function initMap(init_lat=lat_default,init_lng=lng_default, zoom=zo
       map.easeTo({center: [lng, lat]})
 
       const url = new URL(window.location);
-      url.searchParams.set("lat", lat);
-      url.searchParams.set("lng", lng);
+      url.searchParams.set("lat", String(lat));
+      url.searchParams.set("lng", String(lng));
       history.pushState({}, "", url)
     })
   })


### PR DESCRIPTION
Currently, we use the lat and lng query params to navigate to a position on the map and to display a google streetview image. (So, loading https://empty.nyc/?lat=40.69412509192949&lng=-73.94440406650736 will take you to the property at that lat and lng) Example:

<img width="250" alt="Screenshot 2026-07-19 at 12 58 59 PM" src="https://github.com/user-attachments/assets/8cbdc31c-713a-40df-9027-b0954bdaaac3" />

BUT, we currently do not show the detail popup for that property. This PR fixes that, and refactors some of the UI logic:

<img width="250" alt="Screenshot 2026-07-19 at 1 02 43 PM" src="https://github.com/user-attachments/assets/5c73e539-8866-4461-9abe-6b7c0d5514e3" />

This makes URLs portable and more useful -- users can share URLs with others who can now see the relevant details for that property when the page loads.