### PR TITLE
Update permit schema and schema generator

### DIFF
--- a/build/gen_string_schema.sh
+++ b/build/gen_string_schema.sh
@@ -14,7 +14,13 @@ set -euo pipefail
 src="${1:?usage: gen_string_schema.sh <csv-path-or-gs-uri>}"
 
 if [[ "$src" == gs://* ]]; then
-  header="$(gcloud storage cat "$src" 2>/dev/null | head -1 || true)"
+  # Ranged read: `gcloud storage cat` without -r streams the whole object, which
+  # takes minutes on the multi-GB DOB exports even though we only want line 1.
+  # Require a newline in the chunk rather than piping to `head -1`, which would
+  # silently return a truncated header if one ever exceeded the range.
+  chunk="$(gcloud storage cat -r 0-65535 "$src" 2>/dev/null || true)"
+  [[ "$chunk" == *$'\n'* ]] || { echo "error: no header line in first 64KiB of $src" >&2; exit 1; }
+  header="${chunk%%$'\n'*}"
 else
   header="$(head -1 "$src")"
 fi
@@ -22,8 +28,65 @@ fi
 [[ -n "$header" ]] || { echo "error: could not read header from $src" >&2; exit 1; }
 
 python3 - "$header" <<'PY'
-import sys, json
+import sys, json, re
+
+
+def sanitize(name):
+    """Turn a human-readable CSV header into a legal BigQuery column name.
+
+    BigQuery column names must match ^[A-Za-z_][A-Za-z0-9_]*$. PLUTO headers
+    already do, so this is a no-op there. DOB's exports do not: 47 of the 60
+    headers in the permit dataset are illegal (`Bin #`, `Permittee's Phone #`,
+    `Superintendent First & Last Name`, ...). Without sanitizing, this script
+    cannot generate a usable schema for those datasets at all — which is why
+    build/schemas/permit_issuance.json was hand-written, and how it drifted out
+    of alignment with the real CSV.
+
+    The specific rules below are not arbitrary: they are the rules that
+    reproduce the column names the dbt models already reference, so
+    regenerating a schema does not silently rename columns out from under
+    staging. Each is load-bearing for at least one real header.
+    """
+    s = name.strip()
+
+    # Possessives collapse rather than leaving a stray "s": DOB writes
+    # "Permittee's First Name", and stg_permits reads Permittee_First_Name.
+    # Both ASCII and curly apostrophes appear in the same header row —
+    # "Owner's House #" but "Owner’s House City".
+    s = re.sub(r"[’']s\b", "", s)
+    s = s.replace("’", "").replace("'", "")
+
+    # "#" means "number" in these headers and is dropped by the generic
+    # non-alphanumeric rule below, which would collide "Job #" with "Job".
+    # Spelling it out keeps Job_No / Bin_No / Permit_Sequence_No distinct.
+    s = s.replace("#", "No")
+
+    # "&" is pure connective in "Superintendent First & Last Name"; dropping it
+    # gives Superintendent_First_Last_Name rather than a doubled separator.
+    s = s.replace("&", "")
+
+    # Everything else non-alphanumeric (spaces, ".", "-", "/") becomes "_",
+    # then collapse runs and trim edges so "Job doc. #" -> Job_doc_No rather
+    # than Job_doc__No.
+    s = re.sub(r"[^0-9A-Za-z]+", "_", s)
+    s = re.sub(r"_+", "_", s).strip("_")
+
+    # A name may not start with a digit; prefix rather than drop, so a header
+    # like "2020 Census Tract" stays distinguishable.
+    if not s or not re.match(r"^[A-Za-z_]", s):
+        s = "_" + s
+    return s
+
+
 header = sys.argv[1].rstrip("\r\n")
-cols = [c.strip() for c in header.split(",")]
+cols = [sanitize(c) for c in header.split(",")]
+
+# A duplicate name would make the load fail with a confusing error far from the
+# cause, and a silently deduped one would shift every later column — exactly the
+# failure mode that corrupted the hand-written permit schema. Fail loudly here.
+dupes = sorted({c for c in cols if cols.count(c) > 1})
+if dupes:
+    sys.exit(f"error: sanitized header has duplicate column names: {dupes}")
+
 print(json.dumps([{"name": c, "type": "STRING"} for c in cols], indent=2))
 PY

--- a/build/schemas/permit_issuance.json
+++ b/build/schemas/permit_issuance.json
@@ -1,62 +1,242 @@
 [
-  {"name": "BOROUGH", "type": "STRING"},
-  {"name": "Bin_No", "type": "STRING"},
-  {"name": "House_No", "type": "STRING"},
-  {"name": "Street_Name", "type": "STRING"},
-  {"name": "Job_No", "type": "STRING"},
-  {"name": "Job_doc_No", "type": "STRING"},
-  {"name": "Job_Type", "type": "STRING"},
-  {"name": "Self_Cert", "type": "STRING"},
-  {"name": "Block", "type": "STRING"},
-  {"name": "Lot", "type": "STRING"},
-  {"name": "Community_Board", "type": "STRING"},
-  {"name": "Zip_Code", "type": "STRING"},
-  {"name": "Bldg_Type", "type": "STRING"},
-  {"name": "Residential", "type": "STRING"},
-  {"name": "Special_District_1", "type": "STRING"},
-  {"name": "Special_District_2", "type": "STRING"},
-  {"name": "Work_Type", "type": "STRING"},
-  {"name": "Permit_Status", "type": "STRING"},
-  {"name": "Filing_Status", "type": "STRING"},
-  {"name": "Permit_Type", "type": "STRING"},
-  {"name": "Permit_Sequence_No", "type": "STRING"},
-  {"name": "Permit_Subtype", "type": "STRING"},
-  {"name": "Oil_Gas", "type": "STRING"},
-  {"name": "Site_Fill", "type": "STRING"},
-  {"name": "Filing_Date", "type": "STRING"},
-  {"name": "Issuance_Date", "type": "STRING"},
-  {"name": "Expiration_Date", "type": "STRING"},
-  {"name": "Job_Start_Date", "type": "STRING"},
-  {"name": "Permittee_First_Name", "type": "STRING"},
-  {"name": "Permittee_Last_Name", "type": "STRING"},
-  {"name": "Permittee_Business_Name", "type": "STRING"},
-  {"name": "Permittee_Phone", "type": "STRING"},
-  {"name": "Permittee_License_Type", "type": "STRING"},
-  {"name": "Permittee_License_No", "type": "STRING"},
-  {"name": "Act_as_Superintendent", "type": "STRING"},
-  {"name": "Permittee_Other_Title", "type": "STRING"},
-  {"name": "HIC_License", "type": "STRING"},
-  {"name": "Site_Safety_Mgr_First_Name", "type": "STRING"},
-  {"name": "Site_Safety_Mgr_Last_Name", "type": "STRING"},
-  {"name": "Site_Safety_Mgr_Business_Name", "type": "STRING"},
-  {"name": "Superintendent_First_Last_Name", "type": "STRING"},
-  {"name": "Superintendent_Business_Name", "type": "STRING"},
-  {"name": "Owner_Business_Type", "type": "STRING"},
-  {"name": "Non_Profit", "type": "STRING"},
-  {"name": "Owner_Business_Name", "type": "STRING"},
-  {"name": "Owner_First_Name", "type": "STRING"},
-  {"name": "Owner_Last_Name", "type": "STRING"},
-  {"name": "Owner_House_No", "type": "STRING"},
-  {"name": "Owner_House_Street_Name", "type": "STRING"},
-  {"name": "Owner_House_City", "type": "STRING"},
-  {"name": "Owner_House_State", "type": "STRING"},
-  {"name": "Owner_House_Zip_Code", "type": "STRING"},
-  {"name": "Owner_Phone", "type": "STRING"},
-  {"name": "DOBRunDate", "type": "STRING"},
-  {"name": "PERMIT_SI_NO", "type": "STRING"},
-  {"name": "LATITUDE", "type": "STRING"},
-  {"name": "LONGITUDE", "type": "STRING"},
-  {"name": "COUNCIL_DISTRICT", "type": "STRING"},
-  {"name": "CENSUS_TRACT", "type": "STRING"},
-  {"name": "NTA_NAME", "type": "STRING"}
+  {
+    "name": "BOROUGH",
+    "type": "STRING"
+  },
+  {
+    "name": "Bin_No",
+    "type": "STRING"
+  },
+  {
+    "name": "House_No",
+    "type": "STRING"
+  },
+  {
+    "name": "Street_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Job_No",
+    "type": "STRING"
+  },
+  {
+    "name": "Job_doc_No",
+    "type": "STRING"
+  },
+  {
+    "name": "Job_Type",
+    "type": "STRING"
+  },
+  {
+    "name": "Self_Cert",
+    "type": "STRING"
+  },
+  {
+    "name": "Block",
+    "type": "STRING"
+  },
+  {
+    "name": "Lot",
+    "type": "STRING"
+  },
+  {
+    "name": "Community_Board",
+    "type": "STRING"
+  },
+  {
+    "name": "Zip_Code",
+    "type": "STRING"
+  },
+  {
+    "name": "Bldg_Type",
+    "type": "STRING"
+  },
+  {
+    "name": "Residential",
+    "type": "STRING"
+  },
+  {
+    "name": "Special_District_1",
+    "type": "STRING"
+  },
+  {
+    "name": "Special_District_2",
+    "type": "STRING"
+  },
+  {
+    "name": "Work_Type",
+    "type": "STRING"
+  },
+  {
+    "name": "Permit_Status",
+    "type": "STRING"
+  },
+  {
+    "name": "Filing_Status",
+    "type": "STRING"
+  },
+  {
+    "name": "Permit_Type",
+    "type": "STRING"
+  },
+  {
+    "name": "Permit_Sequence_No",
+    "type": "STRING"
+  },
+  {
+    "name": "Permit_Subtype",
+    "type": "STRING"
+  },
+  {
+    "name": "Oil_Gas",
+    "type": "STRING"
+  },
+  {
+    "name": "Site_Fill",
+    "type": "STRING"
+  },
+  {
+    "name": "Filing_Date",
+    "type": "STRING"
+  },
+  {
+    "name": "Issuance_Date",
+    "type": "STRING"
+  },
+  {
+    "name": "Expiration_Date",
+    "type": "STRING"
+  },
+  {
+    "name": "Job_Start_Date",
+    "type": "STRING"
+  },
+  {
+    "name": "Permittee_First_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Permittee_Last_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Permittee_Business_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Permittee_Phone_No",
+    "type": "STRING"
+  },
+  {
+    "name": "Permittee_License_Type",
+    "type": "STRING"
+  },
+  {
+    "name": "Permittee_License_No",
+    "type": "STRING"
+  },
+  {
+    "name": "Act_as_Superintendent",
+    "type": "STRING"
+  },
+  {
+    "name": "Permittee_Other_Title",
+    "type": "STRING"
+  },
+  {
+    "name": "HIC_License",
+    "type": "STRING"
+  },
+  {
+    "name": "Site_Safety_Mgr_First_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Site_Safety_Mgr_Last_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Site_Safety_Mgr_Business_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Superintendent_First_Last_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Superintendent_Business_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_Business_Type",
+    "type": "STRING"
+  },
+  {
+    "name": "Non_Profit",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_Business_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_First_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_Last_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_House_No",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_House_Street_Name",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_House_City",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_House_State",
+    "type": "STRING"
+  },
+  {
+    "name": "Owner_House_Zip_Code",
+    "type": "STRING"
+  },
+  {
+    "name": "PERMIT_SI_NO",
+    "type": "STRING"
+  },
+  {
+    "name": "LATITUDE",
+    "type": "STRING"
+  },
+  {
+    "name": "LONGITUDE",
+    "type": "STRING"
+  },
+  {
+    "name": "COUNCIL_DISTRICT",
+    "type": "STRING"
+  },
+  {
+    "name": "CENSUS_TRACT",
+    "type": "STRING"
+  },
+  {
+    "name": "BBL",
+    "type": "STRING"
+  },
+  {
+    "name": "NTA_NAME",
+    "type": "STRING"
+  },
+  {
+    "name": "DOBRunDate",
+    "type": "STRING"
+  }
 ]

--- a/build/sources.tsv
+++ b/build/sources.tsv
@@ -28,6 +28,7 @@ mappluto	mappluto_26v1	https://s-media.nyc.gov/agencies/dcp/assets/files/zip/dat
 # DOB open datasets (data.cityofnewyork.us) — single CSV, fetched + snapshotted
 # to GCS by build/vendor_dataset.sh  (make vendor.permits / vendor.stalled / vendor.building).
 dob	dob_permit_issuance	https://data.cityofnewyork.us/api/views/ipu4-2q9a/rows.csv?accessType=DOWNLOAD	permit_issuance.csv	NYC Department of Buildings	ipu4-2q9a
+dob	dob_permit_issuance_26v1	https://data.cityofnewyork.us/api/views/ipu4-2q9a/rows.csv?accessType=DOWNLOAD	permit_issuance.csv	NYC Department of Buildings	ipu4-2q9a
 dob	dob_stalled_construction	https://data.cityofnewyork.us/api/views/i296-73x5/rows.csv?accessType=DOWNLOAD	stalled_construction.csv	NYC Department of Buildings	i296-73x5
 dob	dob_building	https://data.cityofnewyork.us/api/views/5zhs-2jue/rows.csv?accessType=DOWNLOAD	building.csv	NYC DOITT	5zhs-2jue
 # Planimetric datasets (data.cityofnewyork.us) — single CSV with WKT geometry,

--- a/build/sources.tsv
+++ b/build/sources.tsv
@@ -28,7 +28,6 @@ mappluto	mappluto_26v1	https://s-media.nyc.gov/agencies/dcp/assets/files/zip/dat
 # DOB open datasets (data.cityofnewyork.us) — single CSV, fetched + snapshotted
 # to GCS by build/vendor_dataset.sh  (make vendor.permits / vendor.stalled / vendor.building).
 dob	dob_permit_issuance	https://data.cityofnewyork.us/api/views/ipu4-2q9a/rows.csv?accessType=DOWNLOAD	permit_issuance.csv	NYC Department of Buildings	ipu4-2q9a
-dob	dob_permit_issuance_26v1	https://data.cityofnewyork.us/api/views/ipu4-2q9a/rows.csv?accessType=DOWNLOAD	permit_issuance.csv	NYC Department of Buildings	ipu4-2q9a
 dob	dob_stalled_construction	https://data.cityofnewyork.us/api/views/i296-73x5/rows.csv?accessType=DOWNLOAD	stalled_construction.csv	NYC Department of Buildings	i296-73x5
 dob	dob_building	https://data.cityofnewyork.us/api/views/5zhs-2jue/rows.csv?accessType=DOWNLOAD	building.csv	NYC DOITT	5zhs-2jue
 # Planimetric datasets (data.cityofnewyork.us) — single CSV with WKT geometry,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3498,9 +3498,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -3641,9 +3641,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3660,7 +3660,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
While syncing permit data with the latest from the DOB, claude pointed out that we're not pulling in a number of columns from the CSV, and that many don't conform to bigquery column name constraints. This makes an update to the schema generator (the previous permit schema was hand-written) that sanitizes column headers.

Should be a no-op since those extra columns are not in use.